### PR TITLE
Made mjml_bin method aware of locally installed node_modules

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -75,7 +75,11 @@ module Mjml
       #
       # @return [String]
       def mjml_bin
-        `/usr/bin/which mjml`.chomp
+        global_bin_path = '/usr/bin/which mjml'.chomp
+        local_bin_path  = File.join(Rails.root, 'node_modules', '.bin', 'mjml')
+      
+        global_bin_path unless File.exist?(local_bin_path)
+        local_bin_path
       end
   end
 end


### PR DESCRIPTION
Hey there,

The `mjml_bin` method currently returns the output of `which mjml` command, which works fine when the module is globally installed but would fail to retrieve a binary when only installed locally.

This pull request intends to fix that by first checking the content of the `node_modules` folder in the current Rails project, then falling back on `which` if there is no local `mjml`.

One question though would be: do we have access to `Rails` in this file?

Ping @pgoetze.