### PR TITLE
Allow developer to specify templating language they use

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -5,6 +5,9 @@ require "mjml/railtie"
 require "rubygems"
 
 module Mjml
+  mattr_accessor :template_language
+
+  @@template_language = :erb
 
   def self.check_version(bin)
     begin
@@ -18,28 +21,32 @@ module Mjml
     # Check for a global install of MJML binary
     mjml_bin = 'mjml'
     return mjml_bin if check_version(mjml_bin)
-    
+
     # Check for a local install of MJML binary
     mjml_bin = File.join(`npm bin`.chomp, 'mjml')
     return mjml_bin if check_version(mjml_bin)
-    
+
     raise RuntimeError, "Couldn't find the MJML binary.. have you run $ npm install mjml?"
   end
 
   BIN = discover_mjml_bin
 
   class Handler
-    def erb_handler
-      @erb_handler ||= ActionView::Template.registered_template_handler(:erb)
+    def template_handler
+      @_template_handler ||= ActionView::Template.registered_template_handler(Mjml.template_language)
     end
 
     def call(template)
-      compiled_source = erb_handler.call(template)
+      compiled_source = template_handler.call(template)
       if template.formats.include?(:mjml)
         "Mjml::Mjmltemplate.to_html(begin;#{compiled_source};end).html_safe"
       else
         compiled_source
       end
     end
+  end
+
+  def self.setup
+    yield self if block_given?
   end
 end


### PR DESCRIPTION
Hey guys.

With this little change developers may specify in any config file (for ex. config/initializers/mjml.rb) templating language they are using, and it should work properly basically for all available templating languages.

Config file should look like this:

```ruby
Mjml.setup do |config|
  config.template_language = :slim # :erb (default), :haml, or any other you are using
end
```

Hope this little change proves to be useful, if you have any ideas to improve this do not hesitate to let me know or update the PR 😄 It kind of solves #3 :wink:

I was looking for better solution, so developer just had to add .slim, or .haml extension to .mjml file, without having config file, but wasn't able to make it work - if anyone has any idea I would be happy to collaborate on this.

For syntax highlighting, I myself use atom with *file-types* addon and it looks and works awesomely, proof:
<img width="1440" alt="screen shot 2016-10-03 at 23 17 14" src="https://cloud.githubusercontent.com/assets/8496729/19054409/92462e9a-89bf-11e6-95af-0dce80b3ddeb.png">

