### PR TITLE
Register the MIME type as an alias

### DIFF
--- a/lib/mjml/railtie.rb
+++ b/lib/mjml/railtie.rb
@@ -5,7 +5,7 @@ module Mjml
 
     initializer "mjml-rails.register_template_handler" do
       ActionView::Template.register_template_handler :mjml, Mjml::Handler.new
-      Mime::Type.register "text/html", :mjml
+      Mime::Type.register_alias "text/html", :mjml
     end
   end
 end


### PR DESCRIPTION
Avoid overriding the existing text/html MIME type by registering the MJML type as an alias.

This should address the issues brought up in #5, and also resolves an issue I've had with an uptime monitoring servicing making requests with an `Accept: text/html` header causing 500 errors in the application due to a "missing template":

> ActionView::MissingTemplate
> Missing template home/index, application/index with {:locale=>[:en], :formats=>[:mjml], :variants=>[], :handlers=>[:erb, :builder, :raw, :ruby, :coffee, :arb, :haml, :mjml]}.