### PR TITLE
Silence output when mjml binary isn't in path

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -10,11 +10,10 @@ module Mjml
   @@template_language = :erb
 
   def self.check_version(bin)
-    begin
-      Gem::Dependency.new('','~> 3.0').match?('',`#{bin} --version`)
-    rescue
-      false
-    end
+    version = IO.popen("#{bin} --version").read.chomp
+    Gem::Dependency.new('', '~> 3.0').match?('', version)
+  rescue
+    false
   end
 
   def self.discover_mjml_bin


### PR DESCRIPTION
When the `mjml` command isn't in the path, error output such as the following will be seen:

```
./bin/rake: No such file or directory - mjml
```

This changes `.check_version` to use `IO.popen` instead so an error will be raised in this case (which is caught by `rescue`, so the method still returns `false`).