### PR TITLE
Only raise when really using mjml if binary is not found

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -25,7 +25,8 @@ module Mjml
     mjml_bin = File.join(`npm bin`.chomp, 'mjml')
     return mjml_bin if check_version(mjml_bin)
 
-    raise RuntimeError, "Couldn't find the MJML binary.. have you run $ npm install mjml?"
+    puts "Couldn't find the MJML binary.. have you run $ npm install mjml?"
+    nil
   end
 
   BIN = discover_mjml_bin

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -5,6 +5,7 @@ module Mjml
     #
     # @param input [String] The string to transform in html
     def initialize input
+      raise "Couldn't find the MJML binary.. have you run $ npm install mjml?" unless mjml_bin
       file = File.open(in_tmp_file, 'w')
       file.write(input)
       file.close


### PR DESCRIPTION
This allows to run a `rake yarn:install` in Rails 5.1 to actually install mjml.
Since rake tasks run through Rails now, it errors out otherwise and
prevents a successful deploy.

`rake yarn:install` is run before `assets:precompile` automatically in
Rails 5.1.