### PR TITLE
Let it work with yarn as well as npm on heroku

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -22,7 +22,8 @@ module Mjml
     return mjml_bin if check_version(mjml_bin)
 
     # Check for a local install of MJML binary
-    mjml_bin = File.join(`npm bin`.chomp, 'mjml')
+    installer_path = (`npm bin` || `yarn bin`).chomp
+    mjml_bin = File.join(installer_path, 'mjml')
     return mjml_bin if check_version(mjml_bin)
 
     puts "Couldn't find the MJML binary.. have you run $ npm install mjml?"


### PR DESCRIPTION
Because I'm using webpacker, npm isn't installed, but yarn is.

Because npm isn't installed, pushing to heroku fails.