### PR TITLE
Fix version check to clean up after itself 👮‍♀️

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -11,7 +11,7 @@ module Mjml
   @@raise_render_exception = false
 
   def self.check_version(bin)
-    IO.popen("#{bin} --version").read.include?('mjml-core: 4.0.')
+    IO.popen("#{bin} --version") { |io| io.read.include?('mjml-core: 4.0.') }
   rescue
     false
   end


### PR DESCRIPTION
Hi 👋 

first of all: **thanx a ton for building an maintaining this gem 💚** It's really helpful 🤗 

This PR fixes the check for the `mjml` version to clean up after itself and not leave a `node` zombie process lingering around 🧟‍♂️

### scenario
We're using `Sidekiq` to send emails in background jobs and our workers always had some _"defunct"_ node processes lingering around forever - even directly after starting / restarting Sidekiq.

### problem

This line in `mjml.rb` 👇 
```ruby
IO.popen("#{bin} --version").read.include?('mjml-core: 4.0.')
```
This runs `mjml --version` as a subprocess. But since the IO object is never closed, the process never gets terminated.

### solution

Looking at the [docs for IO#popen](https://ruby-doc.org/core-2.5.0/IO.html#method-c-popen), the method can also take a block, like so:
```ruby
IO.popen("#{bin} --version") do |io|
  io.read.include?('mjml-core: 4.0.')
end
```
☝️ this will do the exact same as the example above, but also clean up after itself, closing the pipe again. The docs on that:
> If a block is given, Ruby will run the command as a child connected to Ruby with a pipe. Ruby's end of the pipe will be passed as a parameter to the block. At the end of block, Ruby closes the pipe and sets $?. In this case IO.popen returns the value of the block.

So I think this is the better fit for the version check: no zombie `node` processes lingering around any more 🎉 