### PR TITLE
mjml 4.1.0 support 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mjml-rails (4.0.3)
+    mjml-rails (4.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ An example template might look like:
     <mj-preview>Hello World</mj-preview>
   </mj-head>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>Hello World</mj-text>
-          <%= render :partial => 'info', :formats => [:html] %>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>Hello World</mj-text>
+        <%= render :partial => 'info', :formats => [:html] %>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>
 ```
@@ -151,9 +149,7 @@ Email layout:
 <!-- views/layouts/default.mjml -->
 <mjml>
 	<mj-body>
-		<mj-container>
-			<%= yield %>
-		</mj-container>
+		<%= yield %>
 	</mj-body>
 </mjml>
 ```

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -9,7 +9,7 @@ module Mjml
 
   @@template_language = :erb
   @@raise_render_exception = false
-  @@mjml_binary_version_supported = "4.0."
+  @@mjml_binary_version_supported = "4.1."
   @@mjml_binary_error_string = "Couldn't find the MJML #{Mjml.mjml_binary_version_supported} binary.. have you run $ npm install mjml?"
 
   def self.check_version(bin)

--- a/lib/mjml/version.rb
+++ b/lib/mjml/version.rb
@@ -1,4 +1,4 @@
 module Mjml
 	# Version number no longer matches MJML.io version
-  VERSION = "4.0.3"
+  VERSION = "4.1.0"
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -47,7 +47,7 @@ describe Mjml::Parser do
       before { Open3.stubs(popen3: [nil, nil, stderr, nil]) }
 
       it 'raises exception' do
-        -> { parser.run }.must_raise(Mjml::Parser::ParseError, error)
+        -> { parser.run "/tmp/input_file.mjml" }.must_raise(Mjml::Parser::ParseError, error)
       end
     end
   end

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -1,9 +1,9 @@
 require "test_helper"
 
 class MjmlTest < ActiveSupport::TestCase
-  
+
   test 'with Mjmltemplate processor' do
-    assert_not_equal "<mj-body></mj-body>", Mjml::Mjmltemplate.to_html("<mjml><mj-body><mj-container><mj-section><mj-column></mj-column></mj-section></mj-container></mj-body></mjml>").strip
+    assert_not_equal "<mj-body></mj-body>", Mjml::Mjmltemplate.to_html("<mjml><mj-body><mj-section><mj-column></mj-column></mj-section></mj-body></mjml>").strip
   end
 
 end

--- a/test/views/notifier/contact.mjml
+++ b/test/views/notifier/contact.mjml
@@ -1,12 +1,10 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>Hello World</mj-text>
-          <%= render :partial => 'link', :formats => [:html] %>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>Hello World</mj-text>
+        <%= render :partial => 'link', :formats => [:html] %>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>

--- a/test/views/notifier/no_partial.mjml
+++ b/test/views/notifier/no_partial.mjml
@@ -1,11 +1,9 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>Hello World</mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>Hello World</mj-text>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>

--- a/test/views/notifier/user.mjml
+++ b/test/views/notifier/user.mjml
@@ -1,12 +1,10 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>Hello World</mj-text>
-          <%= render :partial => 'user_info', :formats => [:html] %>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>Hello World</mj-text>
+        <%= render :partial => 'user_info', :formats => [:html] %>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>

--- a/test/views/template_subdir/simple.mjml
+++ b/test/views/template_subdir/simple.mjml
@@ -1,11 +1,9 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>This template is in an alternate sub-directory</mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>This template is in an alternate sub-directory</mj-text>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>

--- a/test/views/template_subdir/simple_block_and_path.mjml
+++ b/test/views/template_subdir/simple_block_and_path.mjml
@@ -1,11 +1,9 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>This template is in an alternate sub-directory</mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>This template is in an alternate sub-directory</mj-text>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>

--- a/test/views/template_subdir/simple_with_path.mjml
+++ b/test/views/template_subdir/simple_with_path.mjml
@@ -1,11 +1,9 @@
 <mjml>
   <mj-body>
-    <mj-container>
-      <mj-section>
-        <mj-column>
-          <mj-text>This template is in an alternate sub-directory</mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-container>
+    <mj-section>
+      <mj-column>
+        <mj-text>This template is in an alternate sub-directory</mj-text>
+      </mj-column>
+    </mj-section>
   </mj-body>
 </mjml>


### PR DESCRIPTION
Installing `mjml@4.0.3` is currently pulling in `miml-core: 4.1.0` so the version checking wasn't working anymore.

I also:

* Removed references to `<mj-container>` to get tests passing again
* Switched to using `Tempfile` in `parser.rb` after I had some filename conflicts.