### PR TITLE
Expanded MJML root tag breaks rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An example template might look like:
 </mjml>
 ```
 
-And the partial `_info.mjml`:
+And the partial:
 
 ```erb
 <!-- ./app/views/user_mailer/_info.html.erb -->

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -49,7 +49,7 @@ module Mjml
       # by MJML library when top-level layout/template is rendered
       #
       # [0] - https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mjml
-      if compiled_source =~ /<mjml>/
+      if compiled_source =~ /<mjml(.+)?>/i
         "Mjml::Mjmltemplate.to_html(begin;#{compiled_source};end).html_safe"
       else
         compiled_source

--- a/test/views/no_layout_mailer/inform_contact.mjml
+++ b/test/views/no_layout_mailer/inform_contact.mjml
@@ -1,4 +1,4 @@
-<mjml>
+<mjml owa="desktop">
   <mj-body>
     <mj-section>
       <%= render partial: "user_header", formats: [:html] %>


### PR DESCRIPTION
Expanded MJML root tag `<mjml owa="desktop">` results in message not rendering to HTML.