### PR TITLE
Increase supported mjml binary version to 4.2.

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -9,7 +9,7 @@ module Mjml
 
   @@template_language = :erb
   @@raise_render_exception = false
-  @@mjml_binary_version_supported = "4.1."
+  @@mjml_binary_version_supported = "4.2."
   @@mjml_binary_error_string = "Couldn't find the MJML #{Mjml.mjml_binary_version_supported} binary.. have you run $ npm install mjml?"
 
   def self.check_version(bin)


### PR DESCRIPTION
There was a new mjml release three das ago,
increasing the version from 4.1.2 to 4.2.0 
(https://github.com/mjmlio/mjml/releases).

With this package the binary check failed and reported: 
> Couldn't find the MJML 4.1. binary.. have you run $ npm install mjml?

We need a new gem version supporting the 4.2.x mjml package.

#39