### PR TITLE
swap order of mjml/text in format block

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ class DeviseMailer < Devise::Mailer
       to: record.email,
       subject: "Custom subject"
     ) do |format|
-      format.mjml
       format.text
+      format.mjml
     end
   end
 end


### PR DESCRIPTION
The current example of formatting in the readme will cause some clients (such as gmail) to only display the text version. The enhanced html version should always be last.

From the Multipart RFC 1341 spec:

> In general, user agents that compose multipart/alternative entities should place the body parts in increasing order of preference, that is, with the preferred format last. For fancy text, the sending user agent should put the plainest format first and the richest format last.