### PR TITLE
Escape path when checking MJML binary version

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -15,7 +15,7 @@ module Mjml
   @@minify = false
 
   def self.check_version(bin)
-    IO.popen("#{bin} --version") { |io| io.read.include?("mjml-core: #{Mjml.mjml_binary_version_supported}") }
+    IO.popen([bin, '--version']) { |io| io.read.include?("mjml-core: #{Mjml.mjml_binary_version_supported}") }
   rescue
     false
   end


### PR DESCRIPTION
To better support paths with spaces and other characters that need escaping, use the array form of `IO.popen`'s `cmd` argument which will handle escaping for us.