### PR TITLE
Fix discovering mjml binary when npm is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ gemfile:
 notifications:
   email: true
 before_script:
-  - nvm install 7
+  - nvm install 10
   - npm install mjml
   - npm install promise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Fix discovering mjml binary, when only yarn, but not npm is installed
+
 ## 4.3.0
 
 * Paul Mucur added better path escaping on the IO.popen command. Markus Doits added Rails 6 support by adding the optional second source parameter to template handler calls.
@@ -86,4 +90,3 @@
 * Supports MJML 1.x
 * Allows use of ERb in templates
 * Allows use of partials in templates
-

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -27,11 +27,22 @@ module Mjml
     return mjml_bin if check_version(mjml_bin)
 
     # Check for a local install of MJML binary
-    installer_path = (`npm bin` || `yarn bin`).chomp
+    installer_path = bin_path_from('npm') || bin_path_from('yarn')
+    unless installer_path
+      puts Mjml.mjml_binary_error_string
+      return nil
+    end
+
     mjml_bin = File.join(installer_path, 'mjml')
     return mjml_bin if check_version(mjml_bin)
 
     puts Mjml.mjml_binary_error_string
+    nil
+  end
+
+  def self.bin_path_from(package_manager)
+    `#{package_manager} bin`.chomp
+  rescue Errno::ENOENT # package manager is not installed
     nil
   end
 


### PR DESCRIPTION
This pull requests fixes discovery of the `mjml` binary, when there is only yarn (but no npm) installed.

In case a binary called through backticks is missing, ruby will raise `Errno::ENOENT`.

Thus the previous code failed to discover the bin path, when npm
was not present on the system, because an error was raised immediately.

### Reproduction

On a system that has `yarn` installed, but no `npm` (e.g. in a docker image) try booting your Rails application. Prior this PR, it should error out:
```
$ be rake -T
rake aborted!
Errno::ENOENT: No such file or directory - npm
/home/jan/development/hub/myapp/config/application.rb:20:in `<top (required)>'
/home/jan/development/hub/myapp/Rakefile:3:in `require'
/home/jan/development/hub/myapp/Rakefile:3:in `<top (required)>'
```