### PR TITLE
prioritize local over global and pass full path of binary

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -22,14 +22,14 @@ module Mjml
   end
 
   def self.discover_mjml_bin
-    # Check for a global install of MJML binary
-    mjml_bin = 'mjml'
-    return mjml_bin if check_version(mjml_bin)
-
     # Check for a local install of MJML binary
     installer_path = (`npm bin` || `yarn bin`).chomp
     mjml_bin = File.join(installer_path, 'mjml')
     return mjml_bin if check_version(mjml_bin)
+
+    # Check for a global install of MJML binary
+    mjml_bin = 'mjml'
+    return `which #{mjml_bin}`.chomp if check_version(mjml_bin)
 
     puts Mjml.mjml_binary_error_string
     nil


### PR DESCRIPTION
Currently experiencing some problems in production with email sending. The problem is that Sidekiq is calling `mjml` and it appears to sometimes not know the full path. When using `mjml` it should always call the full path so that it's `/usr/local/bin/mjml` and knows exactly where to read it.

Another issue is that local should always take precedence over global so that a system can upgrade without worrying about a whole machines version.