### PR TITLE
Use Open3 instead of backticks

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -42,9 +42,8 @@ module Mjml
   end
 
   def self.bin_path_from(package_manager)
-    Open3.popen3("#{package_manager} bin") do |stdin, stdout, stderr, thread|
-      stdout.read.chomp
-    end
+    _, stdout, _, _ = Open3.popen3("#{package_manager} bin")
+   stdout.read.chomp
   rescue Errno::ENOENT # package manager is not installed
     nil
   end

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -4,6 +4,7 @@ require "action_view/template"
 require "mjml/mjmltemplate"
 require "mjml/railtie"
 require "rubygems"
+require "open3"
 
 module Mjml
   mattr_accessor :template_language, :raise_render_exception, :mjml_binary_version_supported, :mjml_binary_error_string, :beautify, :minify
@@ -41,7 +42,9 @@ module Mjml
   end
 
   def self.bin_path_from(package_manager)
-    `#{package_manager} bin`.chomp
+    Open3.popen3("#{package_manager} bin") do |stdin, stdout, stderr, thread|
+      stdout.read.chomp
+    end
   rescue Errno::ENOENT # package manager is not installed
     nil
   end


### PR DESCRIPTION
The fix introduced in https://github.com/sighmon/mjml-rails/commit/f05d2bf2e06aa1251ee0a6c7c45dd4f987090722 is not working for me when npm is not installed. 

`` `npm bin` `` returns `nil` instead of throwing an exception, so we get a `NoMethodError` on `chomp` . This seems to be caused by rails overriding backticks: https://github.com/rails/rails/blob/v5.1.4/activesupport/lib/active_support/core_ext/kernel/agnostics.rb

This PR uses `Open3` instead to find the bin path. 