### PR TITLE
Refactor discovery of binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,19 @@ Run the following command to install it:
 bundle install
 ```
 
-Install the MJML parser (optional -g to install it globally):
+Add the MJML parser to your project with your favourite package manager:
 
 ```console
-npm install -g mjml
+# with npm
+npm install mjml
+
+# with yarn
+yarn add mjml
 ```
 
-Note that you'll need at least Node.js version 6 for MJML to function properly.
+MJML-Rails falls back to a global installation of MJML but it is strongly recommended to add MJML directly to your project.
+
+You'll need at least Node.js version 6 for MJML to function properly.
 
 If you're using ```:haml``` or any other Rails template language, create an initializer to set it up:
 

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -33,14 +33,14 @@ module Mjml
   def self.discover_mjml_bin
     # Check for local install of MJML with yarn
     yarn_bin = `which yarn`.chomp
-    if yarn_bin
+    if yarn_bin.present?
       mjml_bin = "#{yarn_bin} run mjml"
       return mjml_bin if check_version(mjml_bin)
     end
 
     # Check for a local install of MJML with npm
     npm_bin = `which npm`.chomp
-    if npm_bin && (installer_path = bin_path_from(npm_bin))
+    if npm_bin.present? && (installer_path = bin_path_from(npm_bin)).present?
       mjml_bin = File.join(installer_path, 'mjml')
       return mjml_bin if check_version(mjml_bin)
     end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -35,9 +35,9 @@ module Mjml
     # @return [String] The result as string
     def run(in_tmp_file, beautify=true, minify=false, validation_level="soft")
       Tempfile.create(["out", ".html"]) do |out_tmp_file|
-        command = "#{mjml_bin} -r #{in_tmp_file} -o #{out_tmp_file.path} --config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
-        _, _, stderr, _ = Open3.popen3(command)
-        raise ParseError.new(stderr.read.chomp) unless stderr.eof?
+        command = "-r #{in_tmp_file} -o #{out_tmp_file.path} --config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
+        _, stderr, status = Mjml.run_mjml(command)
+        raise ParseError.new(stderr.chomp) unless status.success?
         out_tmp_file.read
       end
     end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -66,14 +66,10 @@ describe Mjml::Parser do
   end
 
   describe '#run' do
-    describe 'when shell command is failed' do
-      let(:error) { 'shell error' }
-      let(:stderr) { mock('stderr', eof?: false, read: error) }
-
-      before { Open3.stubs(popen3: [nil, nil, stderr, nil]) }
-
+    describe 'when shell command failed' do
       it 'raises exception' do
-        -> { parser.run "/tmp/input_file.mjml" }.must_raise(Mjml::Parser::ParseError, error)
+        err = _ { parser.run "/tmp/non_existent_file.mjml" }.must_raise(Mjml::Parser::ParseError)
+        err.message.must_include 'Command line error'
       end
     end
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -21,7 +21,8 @@ describe Mjml::Parser do
         end
 
         it 'raises exception' do
-          -> { parser.render }.must_raise(custom_error_class, error.message)
+          err = expect { parser.render }.must_raise(custom_error_class)
+          expect(err.message).must_equal error.message
         end
       end
 
@@ -33,7 +34,7 @@ describe Mjml::Parser do
         end
 
         it 'returns empty string' do
-          parser.render.must_equal ''
+          expect(parser.render).must_equal ''
         end
       end
     end
@@ -68,8 +69,8 @@ describe Mjml::Parser do
   describe '#run' do
     describe 'when shell command failed' do
       it 'raises exception' do
-        err = _ { parser.run "/tmp/non_existent_file.mjml" }.must_raise(Mjml::Parser::ParseError)
-        err.message.must_include 'Command line error'
+        err = expect { parser.run "/tmp/non_existent_file.mjml" }.must_raise(Mjml::Parser::ParseError)
+        expect(err.message).must_include 'Command line error'
       end
     end
   end


### PR DESCRIPTION
This is my try to make binary detection better and more error prone:

    refactor detection of binary and unify executing mjml

    - detect local first, then global
    - use `yarn run` if installed with yarn, makes it work with yarn v2
    - only use bin path when installed with npm, yarn should always work
      with `yarn run`
    - always execute mjml in the same way, whether when checking version or
      transforming mail

This should fix #55.

Second commit:

    always use full paths for binaries

Should fix #63