### PR TITLE
Change default validation level to `strict` and honor `validation_level`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,20 @@ If there are configurations you'd like change:
 - render errors: defaults to `true` (errors raised)
 - minify: defaults to `false` (not minified)
 - beautify: defaults to `true` (beautified)
-- validation_level: defaults to `soft` (MJML syntax validation)
+- validation_level: defaults to `strict` (abort on any template error, see [MJML validation documentation](https://github.com/mjmlio/mjml/tree/master/packages/mjml-validator#validating-mjml) for possible values)
 
 ```ruby
 # config/initializers/mjml.rb
 Mjml.setup do |config|
-  # set to `false` to ignore errors silently
-  config.raise_render_exception = true
+  # ignore errors silently
+  config.raise_render_exception = false
 
   # optimize the size of your email
   config.beautify = false
   config.minify = true
-  config.validation_level = "strict"
+
+  # render illformed MJML templates, not recommended
+  config.validation_level = "soft"
 end
 ```
 

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -15,7 +15,7 @@ module Mjml
   @@mjml_binary_error_string = "Couldn't find the MJML #{Mjml.mjml_binary_version_supported} binary.. have you run $ npm install mjml?"
   @@beautify = true
   @@minify = false
-  @@validation_level = "soft"
+  @@validation_level = "strict"
 
   def self.check_version(bin)
     stdout, _, status = run_mjml('--version', mjml_bin: bin)

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -33,11 +33,12 @@ module Mjml
     # Exec mjml command
     #
     # @return [String] The result as string
-    def run(in_tmp_file, beautify=true, minify=false, validation_level="soft")
+    def run(in_tmp_file, beautify=true, minify=false, validation_level="strict")
       Tempfile.create(["out", ".html"]) do |out_tmp_file|
         command = "-r #{in_tmp_file} -o #{out_tmp_file.path} --config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
-        _, stderr, _ = Mjml.run_mjml(command)
-        raise ParseError.new(stderr.chomp) unless stderr.blank?
+        _, stderr, status = Mjml.run_mjml(command)
+        raise ParseError.new(stderr.chomp) unless status.success?
+        Mjml.logger.warn(stderr.chomp) unless stderr.blank?
         out_tmp_file.read
       end
     end

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -13,6 +13,14 @@ class NotifierMailer < ActionMailer::Base
       format.html
     end
   end
+
+  def invalid_template(recipient)
+    @recipient = recipient
+
+    mail(to: @recipient, from: "app@example.com") do |format|
+      format.html
+    end
+  end
 end
 
 class NoLayoutMailer < ActionMailer::Base
@@ -57,6 +65,11 @@ class NotifierMailerTest < ActiveSupport::TestCase
 
     assert email.text_part.body.match(/We inform you about something/)
     assert email.text_part.body.match(%r{Please visit https://www.example.com})
+  end
+
+  test "Invalid template raises error correctly" do
+    email = NotifierMailer.invalid_template("user@example.com")
+    assert_raise(ActionView::Template::Error) { email.html_part.to_s }
   end
 end
 

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -67,9 +67,18 @@ class NotifierMailerTest < ActiveSupport::TestCase
     assert email.text_part.body.match(%r{Please visit https://www.example.com})
   end
 
-  test "Invalid template raises error correctly" do
-    email = NotifierMailer.invalid_template("user@example.com")
-    assert_raise(ActionView::Template::Error) { email.html_part.to_s }
+  test "Invalid template raises error with validation level strict" do
+    with_settings(validation_level: 'strict') do
+      email = NotifierMailer.invalid_template("user@example.com")
+      assert_raise(ActionView::Template::Error) { email.html_part.to_s }
+    end
+  end
+
+  test "Invalid template gets compiled with validation level soft" do
+    with_settings(validation_level: 'soft') do
+      email = NotifierMailer.invalid_template("user@example.com")
+      assert email.html_part.to_s.blank?
+    end
   end
 end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -13,46 +13,28 @@ describe Mjml::Parser do
         parser.stubs(:run).raises(error)
       end
 
-      describe 'when render exception raising is enabled' do
-        before do
-          Mjml.setup do |config|
-            config.raise_render_exception = true
-          end
-        end
-
-        it 'raises exception' do
+      it 'raises exception with render exception enabled' do
+        with_settings(raise_render_exception: true) do
           err = expect { parser.render }.must_raise(custom_error_class)
           expect(err.message).must_equal error.message
         end
       end
 
-      describe 'when render exception raising is disabled' do
-        before do
-          Mjml.setup do |config|
-            config.raise_render_exception = false
-          end
-        end
-
-        after do
-          Mjml.setup do |config|
-            config.raise_render_exception = true
-          end
-        end
-
-        it 'returns empty string' do
+      it 'returns empty string with exception raising disabled' do
+        with_settings(raise_render_exception: false) do
           expect(parser.render).must_equal ''
         end
       end
     end
 
     describe 'can read beautify, minify, and validation_level configs' do
-      it 'use defaults if no config is set' do
+      it 'uses defaults if no config is set' do
         expect(Mjml.beautify).must_equal(true)
         expect(Mjml.minify).must_equal(false)
         expect(Mjml.validation_level).must_equal('soft')
       end
 
-      it 'use setup config' do
+      it 'uses setup config' do
         Mjml.setup do |config|
           config.beautify = false
           config.minify = true

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -33,6 +33,12 @@ describe Mjml::Parser do
           end
         end
 
+        after do
+          Mjml.setup do |config|
+            config.raise_render_exception = true
+          end
+        end
+
         it 'returns empty string' do
           expect(parser.render).must_equal ''
         end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -31,24 +31,24 @@ describe Mjml::Parser do
       it 'uses defaults if no config is set' do
         expect(Mjml.beautify).must_equal(true)
         expect(Mjml.minify).must_equal(false)
-        expect(Mjml.validation_level).must_equal('soft')
+        expect(Mjml.validation_level).must_equal('strict')
       end
 
       it 'uses setup config' do
         Mjml.setup do |config|
           config.beautify = false
           config.minify = true
-          config.validation_level = 'strict'
+          config.validation_level = 'soft'
         end
 
         expect(Mjml.beautify).must_equal(false)
         expect(Mjml.minify).must_equal(true)
-        expect(Mjml.validation_level).must_equal('strict')
+        expect(Mjml.validation_level).must_equal('soft')
 
         Mjml.setup do |config|
           config.beautify = true
           config.minify = false
-          config.validation_level = 'soft'
+          config.validation_level = 'strict'
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,3 +25,20 @@ I18n.enforce_available_locales = false
 
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true
+
+def with_settings(settings)
+  original_settings =
+    settings.each_with_object({}) do |(key, _), agg|
+      agg[key] = Mjml.public_send(key)
+    end
+
+  settings.each do |key, value|
+    Mjml.public_send("#{key}=", value)
+  end
+
+  yield
+ensure
+  original_settings.each do |key, value|
+    Mjml.public_send("#{key}=", value)
+  end
+end

--- a/test/views/notifier_mailer/invalid_template.html.erb
+++ b/test/views/notifier_mailer/invalid_template.html.erb
@@ -1,0 +1,3 @@
+<mj-invalid>
+  This is invalid
+</mj-text>


### PR DESCRIPTION
**Note**: This is based on top of #71. Please first look at #71, so hopefully #71 can be merged and then there will be fewer changes here. Then you can take a look at this one.

**Second note**: If this is merged and released, there should be a major version bump (I'd say `4.5`) with a changelog entry, because it is a possible backwards incompatible change if somebody has:

- manually set validation level to `soft` (e.g. is not using the default config) and
- relies on MJML-Rails raising an error on any template error, which it wouldn't do then anymore

---

Before this commit MJML-Rails *always* raised an exception if there is any
template validation error.

In MJML there are [two validation levels](https://github.com/mjmlio/mjml/tree/master/packages/mjml-validator#validating-mjml) though (besides disabling
validation completely):

- `strict`: Raise an error if there are any problems, abort
- `soft`: Do your best and compile what you can, but do not raise any
  error. Output errors on stderr.

Right now it does not matter what validation level is used in
MJML-Rails: It always raises an error if something is wrong with the
template, which actually makes the setting `MJML.validation_level`
superfluous.

With this commit, MJML-Rails follows the MJML convention to only abort
if the validation level is `strict`. If it is `soft`, it lets MJML do
what it can and only logs the errors, like MJML does.

To prevent apps using the default configuration from breaking, the
default validation level is changed to `strict`, too. This means it
raises an error on an invalid template like it did before.