### PR TITLE
Fix name of the example email template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 An example template might look like:
 
 ```erb
-<!-- ./app/views/user_mailer/email.html.mjml -->
+<!-- ./app/views/user_mailer/user_signup_confirmation.mjml -->
 <mjml>
   <mj-head>
     <mj-preview>Hello World</mj-preview>


### PR DESCRIPTION
It's not so about the name itself (which isn't hard to guess is incorrect), as about the `.html.mjml` extension - I realized that `.html` should be removed only after reading the post linked below in the README. Until then I was receiving
![image](https://user-images.githubusercontent.com/1934180/108007279-3bc7da00-7006-11eb-97dc-4b9270e1bf56.png)
