### PR TITLE
Fix MJML syntax documentation reference

### DIFF
--- a/lib/mjml/handler.rb
+++ b/lib/mjml/handler.rb
@@ -25,7 +25,7 @@ module Mjml
       # Therefore we skip MJML processing and return raw compiled source. It will be processed
       # by MJML library when top-level layout/template is rendered
       #
-      # [0] - https://github.com/mjmlio/mjml/blob/master/doc/guide.md#mjml
+      # [0] - https://github.com/mjmlio/mjml/blob/master/doc/components_1.md#mjml
       if compiled_source =~ /<mjml.*?>/i
         "Mjml::Parser.new(begin;#{compiled_source};end).render.html_safe"
       else


### PR DESCRIPTION
This reference had been migrated to a different documentation page on the mjml repo.