### PR TITLE
`ParseError` in `Mjml::Parser#run` includes the process status for debugging purposes.

### DIFF
--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -41,7 +41,12 @@ module Mjml
         command = "-r #{in_tmp_file} -o #{out_tmp_file.path} " \
                   "--config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
         _, stderr, status = Mjml.run_mjml(command)
-        raise ParseError, stderr.chomp unless status.success?
+
+        unless status.success?
+          # The process status ist quite helpful in case of dying processes without STDERR output.
+          # Node exit codes are documented here: https://node.readthedocs.io/en/latest/api/process/#exit-codes
+          raise ParseError, "#{stderr.chomp}\n(process status: #{status})"
+        end
 
         Mjml.logger.warn(stderr.chomp) if stderr.present?
         out_tmp_file.read

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -66,9 +66,16 @@ describe Mjml::Parser do
 
   describe '#run' do
     describe 'when shell command failed' do
+      let(:error_msg) do
+        expect { parser.run '/tmp/non_existent_file.mjml' }.must_raise(Mjml::Parser::ParseError).message
+      end
+
       it 'raises exception' do
-        err = expect { parser.run '/tmp/non_existent_file.mjml' }.must_raise(Mjml::Parser::ParseError)
-        expect(err.message).must_include 'Command line error'
+        expect(error_msg).must_include 'Command line error'
+      end
+
+      it 'includes process status' do
+        expect(error_msg).must_match(/\(process status: .+\)/)
       end
     end
   end


### PR DESCRIPTION
Fixes #91