### PR TITLE
Fix Sidekiq memory errors: use posix-spawn instead of ruby Process.spawn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source 'https://rubygems.org'
 gemspec
 gem 'rails', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+
+gem 'posix-spawn', '~> 0.3.15'

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -109,7 +109,7 @@ module Mjml
     yield self if block_given?
   end
 
-  def capture3(cmd)
+  def self.capture3(cmd)
     pid, stdin, stdout, stderr = POSIX::Spawn.popen4(cmd)
     stdin.close
     out = stdout.read

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -110,7 +110,7 @@ module Mjml
   end
 
   def capture3(cmd)
-    pid, stdin, stdout, stderr = popen4(cmd)
+    pid, stdin, stdout, stderr = POSIX::Spawn.popen4(cmd)
     stdin.close
     out = stdout.read
     err = stderr.read
@@ -118,7 +118,6 @@ module Mjml
     [out, err, status]
   ensure
     [stdin, stdout, stderr].each { |io| io.close unless io.closed? }
-    Process.waitpid(pid)
   end
 
   class << self


### PR DESCRIPTION
### Background ℹ️
See https://github.com/macroplant/dochub/pull/8536 for background information.

The `mjml-rails` repo has been forked to our GitHub account and changes made to use `posix-spawn` instead of `Open3`.  

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Steps To Test
See https://github.com/macroplant/dochub/pull/8536 for background information.

#### Issues Closed
- #
