### PR TITLE
Stop running mjml with yarn. Instead fetch the bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,6 @@ Mjml.setup do |config|
 end
 ```
 
-If you are experiencing slow compilation times, you may want to point directly at your binary:
-
-```ruby
-# config/initializers/mjml.rb
-Mjml.setup do |config|
-  config.mjml_binary = Rails.root.join("node_modules/mjml/bin/mjml")
-end
-```
-
 ### MJML v3.x & v4.x support
 
 Version 4.x of this gem brings support for MJML 4.x

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -71,9 +71,9 @@ module Mjml
 
   def self.check_for_yarn_mjml_binary
     yarn_bin = `which yarn`.chomp
-    return if yarn_bin.blank?
+    return unless yarn_bin.present? && (installer_path = bin_path_from(yarn_bin)).present?
 
-    mjml_bin = "#{yarn_bin} run mjml"
+    mjml_bin = File.join(installer_path, 'mjml')
     return mjml_bin if check_version(mjml_bin)
   end
 


### PR DESCRIPTION
Instead of running the bin through yarn (`yarn run mjml`), it makes it work like npm which is a faster way.