### PR TITLE
Add mj-include support and eliminate tempfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.9.0
+
+* Darren Rush refactored the tempfile IO to stdin/stdout and added support for `<mj-include>`.
+
 ## 4.8.0
 
 * Alan Halatian updated the MJML binary discovery when installed with Yarn.

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -37,8 +37,8 @@ module Mjml
     false
   end
 
-  def self.run_mjml(args, mjml_bin: valid_mjml_binary)
-    Open3.capture3("#{mjml_bin} #{args}")
+  def self.run_mjml(args, mjml_bin: valid_mjml_binary, stdin_data: nil)
+    Open3.capture3("#{mjml_bin} #{args}", stdin_data: stdin_data)
   end
 
   def self.valid_mjml_binary

--- a/lib/mjml/handler.rb
+++ b/lib/mjml/handler.rb
@@ -16,6 +16,8 @@ module Mjml
     def call(template, source = nil)
       compiled_source = compile_source(source, template)
 
+      folder = File.dirname(template.identifier)
+
       # Per MJML v4 syntax documentation[0] valid/render'able document MUST start with <mjml> root tag
       # If we get here and template source doesn't start with one it means
       # that we are rendering partial named according to legacy naming convention (partials ending with '.mjml')
@@ -23,8 +25,9 @@ module Mjml
       # by MJML library when top-level layout/template is rendered
       #
       # [0] - https://github.com/mjmlio/mjml/blob/master/doc/components_1.md#mjml
+
       if /<mjml.*?>/i.match?(compiled_source)
-        "Mjml::Parser.new(begin;#{compiled_source};end).render.html_safe"
+        "Mjml::Parser.new(begin;#{compiled_source};end, \"#{folder}\").render.html_safe"
       else
         compiled_source
       end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -5,52 +5,49 @@ module Mjml
     class ParseError < StandardError; end
 
     attr_reader :input
+    attr_reader :path
 
     # Create new parser
     #
     # @param input [String] The string to transform in html
-    def initialize(input)
+    def initialize(input, path)
       raise Mjml.mjml_binary_error_string unless Mjml.valid_mjml_binary
 
       @input = input
+      @path = path
     end
 
     # Render mjml template
     #
     # @return [String]
     def render
-      in_tmp_file = Tempfile.open(['in', '.mjml']) do |file|
-        file.write(input)
-        file # return tempfile from block so #unlink works later
-      end
-      run(in_tmp_file.path, Mjml.beautify, Mjml.minify, Mjml.validation_level)
+      run(input, Mjml.beautify, Mjml.minify, Mjml.validation_level)
     rescue StandardError
       raise if Mjml.raise_render_exception
 
       ''
     ensure
-      in_tmp_file&.unlink
+      # in_tmp_file&.unlink
     end
 
     # Exec mjml command
     #
     # @return [String] The result as string
     # rubocop:disable Style/OptionalBooleanParameter: Fixing this offense would imply a change in the public API.
-    def run(in_tmp_file, beautify = true, minify = false, validation_level = 'strict')
-      Tempfile.create(['out', '.html']) do |out_tmp_file|
-        command = "-r #{in_tmp_file} -o #{out_tmp_file.path} " \
-                  "--config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
-        _, stderr, status = Mjml.run_mjml(command)
+    def run(input, beautify = true, minify = false, validation_level = 'strict')
+      command = "-i " \
+                "--config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level} " \
+                "--config.filePath #{path}"
+      stdout, stderr, status = Mjml.run_mjml(command, stdin_data: input)
 
-        unless status.success?
-          # The process status ist quite helpful in case of dying processes without STDERR output.
-          # Node exit codes are documented here: https://node.readthedocs.io/en/latest/api/process/#exit-codes
-          raise ParseError, "#{stderr.chomp}\n(process status: #{status})"
-        end
-
-        Mjml.logger.warn(stderr.chomp) if stderr.present?
-        out_tmp_file.read
+      unless status.success?
+        # The process status ist quite helpful in case of dying processes without STDERR output.
+        # Node exit codes are documented here: https://node.readthedocs.io/en/latest/api/process/#exit-codes
+        raise ParseError, "#{stderr.chomp}\n(process status: #{status})"
       end
+
+      Mjml.logger.warn(stderr.chomp) if stderr.present?
+      stdout
     end
     # rubocop:enable Style/OptionalBooleanParameter
   end

--- a/lib/mjml/version.rb
+++ b/lib/mjml/version.rb
@@ -2,5 +2,5 @@
 
 module Mjml
   # Version number no longer matches MJML.io version
-  VERSION = '4.8.0'
+  VERSION = '4.9.0'
 end


### PR DESCRIPTION
This PR has two significant improvements:

1. `<mj-include />` is now supported. This allows it to be used in VS Code with full preview support and during runtime.
2. Eliminated the need to write input and output tempfiles in favor of stdin/stdout to the `mjml` command. 