### PR TITLE
#101 Update GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,20 @@ jobs:
           - npm
           - yarn
         rails_version:
-          - "~> 6.0"
+          - "~> 7.0"
+          - "~> 6.1"
           - "~> 5.2"
         ruby_version:
-          - "2.5"
-          - "2.6"
+          - "3.2"
+          - "3.1"
+          - "3.0"
           - "2.7"
     name: ${{ matrix.package_manager }}, Rails ${{ matrix.rails_version }}, Ruby ${{ matrix.ruby_version }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - name: Set up Node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         package_manager:
           - npm
@@ -17,7 +18,6 @@ jobs:
           - "~> 6.1"
           - "~> 5.2"
         ruby_version:
-          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,7 @@
 ---
 name: test
 on:
-  push:
-    branches:
-      - main
-      - master
+  - push
   - pull_request
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 ---
 name: test
 on:
-  - push
+  push:
+    branches:
+      - main
+      - master
   - pull_request
 
 jobs:
@@ -16,7 +19,6 @@ jobs:
         rails_version:
           - "~> 7.0"
           - "~> 6.1"
-          - "~> 5.2"
         ruby_version:
           - "3.1"
           - "3.0"


### PR DESCRIPTION
Resolves #101

- [x] Migrate to https://github.com/ruby/setup-ruby
- [x] Update Ruby/Rails test versions

## Notes

1. Drops support for [Ruby versions < 2.7](https://endoflife.date/ruby)
1. Drops support for [Rails versions < 6.1](https://endoflife.date/rails)