### PR TITLE
Support for JS Package Manager updates

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -71,10 +71,15 @@ module Mjml
 
   def self.check_for_yarn_mjml_binary
     yarn_bin = `which yarn`.chomp
-    return unless yarn_bin.present? && (installer_path = bin_path_from(yarn_bin)).present?
+    return if yarn_bin.blank?
 
-    mjml_bin = File.join(installer_path, 'mjml')
+    stdout, _, status = Open3.capture3("#{yarn_bin} bin mjml")
+    return unless status.success?
+
+    mjml_bin = stdout.chomp
     return mjml_bin if check_version(mjml_bin)
+  rescue Errno::ENOENT # package manager is not installed
+    nil
   end
 
   def self.check_for_npm_mjml_binary
@@ -93,16 +98,6 @@ module Mjml
   def self.check_for_global_mjml_binary
     mjml_bin = `which mjml`.chomp
     return mjml_bin if mjml_bin.present? && check_version(mjml_bin)
-  end
-
-  def self.bin_path_from(package_manager)
-    stdout, _, status = Open3.capture3("#{package_manager} bin")
-
-    return unless status.success?
-
-    stdout.chomp
-  rescue Errno::ENOENT # package manager is not installed
-    nil
   end
 
   def self.discover_mjml_bin

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -79,10 +79,15 @@ module Mjml
 
   def self.check_for_npm_mjml_binary
     npm_bin = `which npm`.chomp
-    return unless npm_bin.present? && (installer_path = bin_path_from(npm_bin)).present?
+    return if npm_bin.blank?
 
-    mjml_bin = File.join(installer_path, 'mjml')
+    stdout, _, status = Open3.capture3("#{npm_bin} root")
+    return unless status.success?
+
+    mjml_bin = File.join(stdout.chomp, '.bin', 'mjml')
     return mjml_bin if check_version(mjml_bin)
+  rescue Errno::ENOENT # package manager is not installed
+    nil
   end
 
   def self.check_for_global_mjml_binary


### PR DESCRIPTION
Fix: #104

As explained in #104, the behavior of `yarn bin` has changed since yarn 2. Also, the `npm bin` command has been removed since npm 9.
This PR has been modified to support the new versions of yarn and npm as follows.

For yarn, the `yarn bin mjml` command outputs the full path to the mjml binary, so use that.

However, npm does not have such a command, and `npx` and `npm` exec have more overhead than executing the binary directly.

So I used the `npm root` command to get the full path of the local node_modules and appended the `.bin` directory. This is the same path as the result of executing `npm bin`.
Also, the `npm root` command works with npm 6~9.
Refs:
https://docs.npmjs.com/cli/v9/commands/npm-root
https://docs.npmjs.com/cli/v9/configuring-npm/folders?v=true#executables


And I removed the `bin_path_from` method that was common to yarn and npm because of the difference in execution commands and processing.

It works correctly in my Rails Project using npm9, and I have verified it with yarn 2.