### PR TITLE
Allow using MRML via MRML-ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ MJML-Rails has the following settings with defaults:
 ```ruby
 # config/initializers/mjml.rb
 Mjml.setup do |config|
-  # Use :haml as a template languag
+  # Use :haml as a template language
   config.template_language = :haml
 
   # Ignore errors silently

--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ MJML-Rails has the following settings with defaults:
 
    This can be used to specify the path to a custom MJML binary if it is not detected automatically (shouldn't be needed).
 
-- `mjml_binary_version_support: "4."`
+- `mjml_binary_version_supported: "4."`
 
    MJML-Rails checks the version of the MJML binary and fails if it does not start with this version, e.g. if an old version is installed by accident.
 
 - `use_mrml: false`
-  Enabling this will allow you to use Rust implementation of MJML via the `mrml` gem. It comes with prebuilt binaries instead of having to install MJML along with Node. When enabled the options `mjml_binary_version_support`, `mjml_binary`, `minify`, `beautify` and `validation_level` are ignored.
+  Enabling this will allow you to use Rust implementation of MJML via the `mrml` gem. It comes with prebuilt binaries instead of having to install MJML along with Node. When enabled the options `mjml_binary_version_supported`, `mjml_binary`, `minify`, `beautify` and `validation_level` are ignored.
 
 ```ruby
 # config/initializers/mjml.rb

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ end
 
 ## Installation
 
+### Using MJML NPM package
+
 Add it to your Gemfile.
 
 ```ruby
@@ -82,6 +84,34 @@ yarn add mjml
 MJML-Rails falls back to a global installation of MJML but it is strongly recommended to add MJML directly to your project.
 
 You'll need at least Node.js version 6 for MJML to function properly.
+
+### Using MRML with included binaries
+
+If for some reason you can't or don't want to run JS code in your production environment, you can use [MRML](https://github.com/hardpixel/mrml-ruby). It ships with already compiled binaries for Rust implementation of MJML so it has no external dependencies.
+
+Add `mjml-rails` and `mrml` to your Gemfile.
+
+```ruby
+gem 'mjml-rails'
+gem 'mrml'
+```
+
+Run the following command to install it:
+
+```console
+bundle install
+```
+
+Set `use_mrml` option to `true` in your initializer:
+
+```ruby
+# config/initializers/mjml.rb
+Mjml.setup do |config|
+  config.use_mrml = true
+end
+```
+
+**Note**: MRML does not fully support all MJML functionalities, see [Missing implementations](https://github.com/jdrouet/mrml#missing-implementations)
 
 ## Configuration
 
@@ -119,11 +149,13 @@ MJML-Rails has the following settings with defaults:
 
    MJML-Rails checks the version of the MJML binary and fails if it does not start with this version, e.g. if an old version is installed by accident.
 
+- `use_mrml: false`
+  Enabling this will allow you to use Rust implementation of MJML via the `mrml` gem. It comes with prebuilt binaries instead of having to install MJML along with Node. When enabled the options `mjml_binary_version_support`, `mjml_binary`, `minify`, `beautify` and `validation_level` are ignored.
 
 ```ruby
 # config/initializers/mjml.rb
 Mjml.setup do |config|
-  # Use :haml as a template language
+  # Use :haml as a template languag
   config.template_language = :haml
 
   # Ignore errors silently
@@ -135,6 +167,9 @@ Mjml.setup do |config|
 
   # Render MJML templates with errors
   config.validation_level = "soft"
+
+  # Use MRML instead of MJML, false by default
+  config.use_mrml = false
 
   # Use custom MJML binary with custom version
   config.mjml_binary = "/path/to/custom/mjml"

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -5,8 +5,7 @@ require 'open3'
 
 require 'mjml/handler'
 require 'mjml/parser'
-require 'mjml/mrml_parser'
-
+require 'mjml/mrml_parser' if defined?(MRML)
 require 'mjml/railtie' if defined?(Rails)
 
 module Mjml

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -5,6 +5,7 @@ require 'open3'
 
 require 'mjml/handler'
 require 'mjml/parser'
+require 'mjml/mrml_parser'
 
 require 'mjml/railtie' if defined?(Rails)
 
@@ -17,7 +18,8 @@ module Mjml
     :mjml_binary_version_supported,
     :raise_render_exception,
     :template_language,
-    :validation_level
+    :validation_level,
+    :use_mrml
 
   mattr_writer :valid_mjml_binary
 
@@ -29,6 +31,7 @@ module Mjml
   self.beautify = true
   self.minify = false
   self.validation_level = 'strict'
+  self.use_mrml = false
 
   def self.check_version(bin)
     stdout, _, status = run_mjml('--version', mjml_bin: bin)

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -5,7 +5,7 @@ require 'open3'
 
 require 'mjml/handler'
 require 'mjml/parser'
-require 'mjml/mrml_parser' if defined?(MRML)
+require 'mjml/mrml_parser'
 require 'mjml/railtie' if defined?(Rails)
 
 module Mjml

--- a/lib/mjml/handler.rb
+++ b/lib/mjml/handler.rb
@@ -16,6 +16,7 @@ module Mjml
     def call(template, source = nil)
       compiled_source = compile_source(source, template)
 
+      parser_class = Mjml.use_mrml ? 'MrmlParser' : 'Parser'
       # Per MJML v4 syntax documentation[0] valid/render'able document MUST start with <mjml> root tag
       # If we get here and template source doesn't start with one it means
       # that we are rendering partial named according to legacy naming convention (partials ending with '.mjml')
@@ -24,7 +25,7 @@ module Mjml
       #
       # [0] - https://github.com/mjmlio/mjml/blob/master/doc/components_1.md#mjml
       if /<mjml.*?>/i.match?(compiled_source)
-        "Mjml::Parser.new(begin;#{compiled_source};end).render.html_safe"
+        "Mjml::#{parser_class}.new(begin;#{compiled_source};end).render.html_safe"
       else
         compiled_source
       end

--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'mrml'
+
+module Mjml
+  class MrmlParser
+    attr_reader :input
+
+    # Create new parser
+    #
+    # @param input [String] The string to transform in html
+    def initialize(input)
+      @input = input
+    end
+
+    # Render mjml template
+    #
+    # @return [String]
+    def render
+      MRML.to_html(input)
+    rescue StandardError
+      raise if Mjml.raise_render_exception
+
+      ''
+    end
+  end
+end

--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
-
-require 'mrml'
-
 module Mjml
   class MrmlParser
     attr_reader :input

--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -16,6 +16,9 @@ module Mjml
     # @return [String]
     def render
       MRML.to_html(input)
+    rescue NameError
+      Mjml.logger.fatal('MRML is not installed. Please add `gem "mrml"` to your Gemfile.')
+      raise
     rescue StandardError
       raise if Mjml.raise_render_exception
 

--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Mjml
   class MrmlParser
     attr_reader :input

--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'mrml'
 
 module Mjml

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'mrml'
 
 module Mjml
   class Parser
@@ -10,8 +11,6 @@ module Mjml
     #
     # @param input [String] The string to transform in html
     def initialize(input)
-      raise Mjml.mjml_binary_error_string unless Mjml.valid_mjml_binary
-
       @input = input
     end
 
@@ -19,39 +18,7 @@ module Mjml
     #
     # @return [String]
     def render
-      in_tmp_file = Tempfile.open(['in', '.mjml']) do |file|
-        file.write(input)
-        file # return tempfile from block so #unlink works later
-      end
-      run(in_tmp_file.path, Mjml.beautify, Mjml.minify, Mjml.validation_level)
-    rescue StandardError
-      raise if Mjml.raise_render_exception
-
-      ''
-    ensure
-      in_tmp_file&.unlink
+      MRML.to_html(input)
     end
-
-    # Exec mjml command
-    #
-    # @return [String] The result as string
-    # rubocop:disable Style/OptionalBooleanParameter: Fixing this offense would imply a change in the public API.
-    def run(in_tmp_file, beautify = true, minify = false, validation_level = 'strict')
-      Tempfile.create(['out', '.html']) do |out_tmp_file|
-        command = "-r #{in_tmp_file} -o #{out_tmp_file.path} " \
-                  "--config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
-        _, stderr, status = Mjml.run_mjml(command)
-
-        unless status.success?
-          # The process status ist quite helpful in case of dying processes without STDERR output.
-          # Node exit codes are documented here: https://node.readthedocs.io/en/latest/api/process/#exit-codes
-          raise ParseError, "#{stderr.chomp}\n(process status: #{status})"
-        end
-
-        Mjml.logger.warn(stderr.chomp) if stderr.present?
-        out_tmp_file.read
-      end
-    end
-    # rubocop:enable Style/OptionalBooleanParameter
   end
 end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -19,6 +19,10 @@ module Mjml
     # @return [String]
     def render
       MRML.to_html(input)
+    rescue StandardError
+      raise if Mjml.raise_render_exception
+
+      ''
     end
   end
 end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'mrml'
 
 module Mjml
   class Parser
@@ -11,6 +10,8 @@ module Mjml
     #
     # @param input [String] The string to transform in html
     def initialize(input)
+      raise Mjml.mjml_binary_error_string unless Mjml.valid_mjml_binary
+
       @input = input
     end
 
@@ -18,11 +19,39 @@ module Mjml
     #
     # @return [String]
     def render
-      MRML.to_html(input)
+      in_tmp_file = Tempfile.open(['in', '.mjml']) do |file|
+        file.write(input)
+        file # return tempfile from block so #unlink works later
+      end
+      run(in_tmp_file.path, Mjml.beautify, Mjml.minify, Mjml.validation_level)
     rescue StandardError
       raise if Mjml.raise_render_exception
 
       ''
+    ensure
+      in_tmp_file&.unlink
     end
+
+    # Exec mjml command
+    #
+    # @return [String] The result as string
+    # rubocop:disable Style/OptionalBooleanParameter: Fixing this offense would imply a change in the public API.
+    def run(in_tmp_file, beautify = true, minify = false, validation_level = 'strict')
+      Tempfile.create(['out', '.html']) do |out_tmp_file|
+        command = "-r #{in_tmp_file} -o #{out_tmp_file.path} " \
+                  "--config.beautify #{beautify} --config.minify #{minify} --config.validationLevel #{validation_level}"
+        _, stderr, status = Mjml.run_mjml(command)
+
+        unless status.success?
+          # The process status ist quite helpful in case of dying processes without STDERR output.
+          # Node exit codes are documented here: https://node.readthedocs.io/en/latest/api/process/#exit-codes
+          raise ParseError, "#{stderr.chomp}\n(process status: #{status})"
+        end
+
+        Mjml.logger.warn(stderr.chomp) if stderr.present?
+        out_tmp_file.read
+      end
+    end
+    # rubocop:enable Style/OptionalBooleanParameter
   end
 end

--- a/mjml-rails.gemspec
+++ b/mjml-rails.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
   s.require_paths = ['lib']
   s.post_install_message = "Don't forget to install MJML e.g. \n$ npm install mjml"
 
+  s.add_dependency 'mrml'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mocha', '2.1.0'
   s.add_development_dependency 'rails'

--- a/mjml-rails.gemspec
+++ b/mjml-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
   s.require_paths = ['lib']
   s.post_install_message = "Don't forget to install MJML e.g. \n$ npm install mjml"
 
-  s.add_dependency 'mrml'
+  s.add_dependency 'mrml', '~> 1.4.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mocha', '2.1.0'
   s.add_development_dependency 'rails'

--- a/mjml-rails.gemspec
+++ b/mjml-rails.gemspec
@@ -25,10 +25,10 @@ Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
 
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mocha', '2.1.0'
+  s.add_development_dependency 'mrml', '~> 1.4.2'
   s.add_development_dependency 'rails'
   s.add_development_dependency 'rubocop', '~> 1.23.0'
   s.add_development_dependency 'rubocop-performance', '~> 1.12.0'
   s.add_development_dependency 'rubocop-rails', '~> 2.12.4'
   s.add_development_dependency 'warning', '1.2.1'
-  s.add_development_dependency 'mrml', '~> 1.4.2'
 end

--- a/mjml-rails.gemspec
+++ b/mjml-rails.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
   s.require_paths = ['lib']
   s.post_install_message = "Don't forget to install MJML e.g. \n$ npm install mjml"
 
-  s.add_dependency 'mrml', '~> 1.4.2'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'mocha', '2.1.0'
   s.add_development_dependency 'rails'
@@ -31,4 +30,5 @@ Gem::Specification.new do |s| # rubocop:disable Gemspec/RequireMFA
   s.add_development_dependency 'rubocop-performance', '~> 1.12.0'
   s.add_development_dependency 'rubocop-rails', '~> 2.12.4'
   s.add_development_dependency 'warning', '1.2.1'
+  s.add_development_dependency 'mrml', '~> 1.4.2'
 end

--- a/test/mrml_parser_test.rb
+++ b/test/mrml_parser_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Mjml::MrmlParser do
+  let(:input) { mock('input') }
+  let(:parser) { Mjml::MrmlParser.new(input) }
+
+  describe '#render' do
+    describe 'when exception is raised' do
+      let(:custom_error_class) { Class.new(StandardError) }
+      let(:error) { custom_error_class.new('custom error') }
+
+      before do
+        parser.stubs(:run).raises(error)
+      end
+
+      it 'raises exception with render exception enabled' do
+        with_settings(raise_render_exception: true) do
+          err = expect { parser.render }.must_raise(custom_error_class)
+          expect(err.message).must_equal error.message
+        end
+      end
+
+      it 'returns empty string with exception raising disabled' do
+        with_settings(raise_render_exception: false) do
+          expect(parser.render).must_equal ''
+        end
+      end
+    end
+  end
+end

--- a/test/mrml_parser_test.rb
+++ b/test/mrml_parser_test.rb
@@ -15,7 +15,6 @@ describe Mjml::MrmlParser do
     end
 
     describe 'when exception is raised' do
-      let(:error) { custom_error_class.new('custom error') }
       let(:input) { '<mjml><body><mj-text>Hello World</mj-text></body></mjml>' }
 
       it 'raises exception with render exception enabled' do

--- a/test/mrml_parser_test.rb
+++ b/test/mrml_parser_test.rb
@@ -3,22 +3,24 @@
 require 'test_helper'
 
 describe Mjml::MrmlParser do
-  let(:input) { mock('input') }
   let(:parser) { Mjml::MrmlParser.new(input) }
 
   describe '#render' do
-    describe 'when exception is raised' do
-      let(:custom_error_class) { Class.new(StandardError) }
-      let(:error) { custom_error_class.new('custom error') }
+    describe 'when input is valid' do
+      let(:input) { '<mjml><mj-body><mj-text>Hello World</mj-text></mj-body></mjml>' }
 
-      before do
-        parser.stubs(:run).raises(error)
+      it 'returns html' do
+        expect(parser.render).must_include 'Hello World</div>'
       end
+    end
+
+    describe 'when exception is raised' do
+      let(:error) { custom_error_class.new('custom error') }
+      let(:input) { '<mjml><body><mj-text>Hello World</mj-text></body></mjml>' }
 
       it 'raises exception with render exception enabled' do
         with_settings(raise_render_exception: true) do
-          err = expect { parser.render }.must_raise(custom_error_class)
-          expect(err.message).must_equal error.message
+          expect { parser.render }.must_raise(MRML::Error)
         end
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ require 'rails/generators'
 require 'rails/generators/test_case'
 require 'mocha/minitest'
 require 'byebug'
+require 'mrml'
 
 # require "minitest/reporters"
 # Minitest::Reporters.use!


### PR DESCRIPTION
This proof of concept change would allow using Rust implementation of MJML called MRML via the mrml-ruby gem. 

The benefits:

- no need for JS runtime in production to compile email templates
- MRML boasts better performance and lower memory usage
- MRML-ruby gem comes with precompiled binaries for all architectures so much easier to set up
- no need to write to temp files to feed input into MJML


Would anyone except me find this useful?


References:

 - ruby gem: https://github.com/hardpixel/mrml-ruby
 - MRML: https://github.com/jdrouet/mrml

MRML[ isn't 100% compatible](https://github.com/jdrouet/mrml#missing-implementations) with MJML, so I made it optional. 