### PR TITLE
#117 Warning about MJML missing when using MRML

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -48,7 +48,8 @@ module Mjml
                              check_for_custom_mjml_binary ||
                              check_for_yarn_mjml_binary ||
                              check_for_npm_mjml_binary ||
-                             check_for_global_mjml_binary
+                             check_for_global_mjml_binary ||
+                             check_for_mrml_binary
 
     return @@valid_mjml_binary if @@valid_mjml_binary
 
@@ -100,6 +101,13 @@ module Mjml
   def self.check_for_global_mjml_binary
     mjml_bin = `which mjml`.chomp
     return mjml_bin if mjml_bin.present? && check_version(mjml_bin)
+  end
+
+  def self.check_for_mrml_binary
+    MRML.present?
+  rescue NameError
+    Mjml.mjml_binary_error_string = 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'
+    false
   end
 
   def self.discover_mjml_bin

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -119,11 +119,13 @@ describe Mjml do
     before do
       Mjml.mjml_binary = nil
       Mjml.valid_mjml_binary = nil
+      Mjml.use_mrml = nil
     end
 
     after do
       Mjml.mjml_binary = nil
       Mjml.valid_mjml_binary = nil
+      Mjml.use_mrml = nil
     end
 
     it 'can be set to a custom value with mjml_binary if version is correct' do
@@ -155,6 +157,20 @@ describe Mjml do
       err = expect { Mjml.valid_mjml_binary }.must_raise(StandardError)
       assert(err.message.start_with?("MJML.mjml_binary is set to 'set by mjml_binary' " \
                                      'but MJML-Rails could not validate that it is a valid MJML binary'))
+    end
+
+    it 'can use MRML and check for a valid binary' do
+      Mjml.use_mrml = true
+      Mjml.stubs(:check_for_custom_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_yarn_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_npm_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_global_mjml_binary).returns(false)
+      expect(Mjml.valid_mjml_binary).must_equal(true)
+
+      Mjml.valid_mjml_binary = nil
+      MRML.stubs(:present?).raises(NameError)
+      assert_nil(Mjml.valid_mjml_binary)
+      expect(Mjml.mjml_binary_error_string).must_equal 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'
     end
   end
 end


### PR DESCRIPTION
Resolves #117 

- [x] Add a check for a valid MRML binary

## Testing

1. Uninstall/remove `mjml` from your environment
1. Clone and switch to using this branch in your Gemfile: `gem 'mjml-rails', path: '../mjml-rails/'`
1. Add `config.use_mrml = true` to your initializer
1. Add `mrml` to your Gemfile
1. Note the warning of a missing MJML binary no longer occurs