### PR TITLE
Remove deadname from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ npm install -g mjml@3.3.5
 
 ### How to guides
 
-[Hugo Giraudel](https://twitter.com/hugogiraudel) wrote a post on [using MJML in Rails](http://dev.edenspiekermann.com/2016/06/02/using-mjml-in-rails/).
+[Kitty Giraudel](https://twitter.com/KittyGiraudel) wrote a post on [using MJML in Rails](http://dev.edenspiekermann.com/2016/06/02/using-mjml-in-rails/).
 
 ## Using Email Layouts
 


### PR DESCRIPTION
The README's "How to guides" section refers to Kitty Giraudel by their deadname. This PR updates the README to use the name that the author identifies with. (See: https://en.wikipedia.org/wiki/Deadnaming)