### PR TITLE
Add support for the Bun package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ npm install -g mjml
 
 # with yarn
 yarn add mjml
+
+# with bun
+bun add mjml
 ```
 
 MJML-Rails falls back to a global installation of MJML but it is strongly recommended to add MJML directly to your project.
@@ -151,9 +154,9 @@ MJML-Rails has the following settings with defaults:
 
 - `use_mrml: false`
   Enabling this will allow you to use Rust implementation of MJML via the `mrml` gem. It comes with prebuilt binaries instead of having to install MJML along with Node. When enabled the options `mjml_binary_version_supported`, `mjml_binary`, `minify`, `beautify` and `validation_level` are ignored.
-  
+
 - `fonts`
-  By default, MJML-Rails uses MJML default fonts, but enables you to override it. 
+  By default, MJML-Rails uses MJML default fonts, but enables you to override it.
   Example : `config.fonts = { Raleway: 'https://fonts.googleapis.com/css?family=Raleway }`
 
 

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -48,9 +48,7 @@ module Mjml
   def self.valid_mjml_binary
     self.valid_mjml_binary = @@valid_mjml_binary ||
                              check_for_custom_mjml_binary ||
-                             check_for_bun_mjml_binary ||
-                             check_for_yarn_mjml_binary ||
-                             check_for_npm_mjml_binary ||
+                             check_for_package_mjml_binary ||
                              check_for_global_mjml_binary ||
                              check_for_mrml_binary
 
@@ -75,43 +73,23 @@ module Mjml
           'it is a valid MJML binary. Please check your configuration.'
   end
 
-  def self.check_for_bun_mjml_binary
-    bun_bin = `which bun`.chomp
-    return if bun_bin.blank?
+  def self.check_for_mjml_package(package_manager, bin_command, binary_path)
+    pm_bin = `which #{package_manager}`.chomp
+    return if pm_bin.blank?
 
-    stdout, _, status = Open3.capture3("#{bun_bin} pm bin")
+    stdout, _, status = Open3.capture3("#{pm_bin} #{bin_command}")
     return unless status.success?
 
-    mjml_bin = File.join(stdout.chomp, 'mjml')
+    mjml_bin = File.join(stdout.chomp, *binary_path)
     return mjml_bin if check_version(mjml_bin)
   rescue Errno::ENOENT # package manager is not installed
     nil
   end
 
-  def self.check_for_yarn_mjml_binary
-    yarn_bin = `which yarn`.chomp
-    return if yarn_bin.blank?
-
-    stdout, _, status = Open3.capture3("#{yarn_bin} bin mjml")
-    return unless status.success?
-
-    mjml_bin = stdout.chomp
-    return mjml_bin if check_version(mjml_bin)
-  rescue Errno::ENOENT # package manager is not installed
-    nil
-  end
-
-  def self.check_for_npm_mjml_binary
-    npm_bin = `which npm`.chomp
-    return if npm_bin.blank?
-
-    stdout, _, status = Open3.capture3("#{npm_bin} root")
-    return unless status.success?
-
-    mjml_bin = File.join(stdout.chomp, '.bin', 'mjml')
-    return mjml_bin if check_version(mjml_bin)
-  rescue Errno::ENOENT # package manager is not installed
-    nil
+  def self.check_for_package_mjml_binary
+    check_for_mjml_package('bun', 'pm bin', ['mjml']) ||
+      check_for_mjml_package('npm', 'root', ['.bin', 'mjml']) ||
+      check_for_mjml_package('yarn', 'bin mjml', [])
   end
 
   def self.check_for_global_mjml_binary

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -48,6 +48,7 @@ module Mjml
   def self.valid_mjml_binary
     self.valid_mjml_binary = @@valid_mjml_binary ||
                              check_for_custom_mjml_binary ||
+                             check_for_bun_mjml_binary ||
                              check_for_yarn_mjml_binary ||
                              check_for_npm_mjml_binary ||
                              check_for_global_mjml_binary ||
@@ -72,6 +73,19 @@ module Mjml
 
     raise "MJML.mjml_binary is set to '#{mjml_binary}' but MJML-Rails could not validate that " \
           'it is a valid MJML binary. Please check your configuration.'
+  end
+
+  def self.check_for_bun_mjml_binary
+    bun_bin = `which bun`.chomp
+    return if bun_bin.blank?
+
+    stdout, _, status = Open3.capture3("#{bun_bin} pm bin")
+    return unless status.success?
+
+    mjml_bin = File.join(stdout.chomp, 'mjml')
+    return mjml_bin if check_version(mjml_bin)
+  rescue Errno::ENOENT # package manager is not installed
+    nil
   end
 
   def self.check_for_yarn_mjml_binary

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -162,6 +162,7 @@ describe Mjml do
     it 'can use MRML and check for a valid binary' do
       Mjml.use_mrml = true
       Mjml.stubs(:check_for_custom_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_bun_mjml_binary).returns(false)
       Mjml.stubs(:check_for_yarn_mjml_binary).returns(false)
       Mjml.stubs(:check_for_npm_mjml_binary).returns(false)
       Mjml.stubs(:check_for_global_mjml_binary).returns(false)

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -162,9 +162,7 @@ describe Mjml do
     it 'can use MRML and check for a valid binary' do
       Mjml.use_mrml = true
       Mjml.stubs(:check_for_custom_mjml_binary).returns(false)
-      Mjml.stubs(:check_for_bun_mjml_binary).returns(false)
-      Mjml.stubs(:check_for_yarn_mjml_binary).returns(false)
-      Mjml.stubs(:check_for_npm_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_package_mjml_binary).returns(false)
       Mjml.stubs(:check_for_global_mjml_binary).returns(false)
       expect(Mjml.valid_mjml_binary).must_equal(true)
 


### PR DESCRIPTION
My team and I recently started using [Bun](https://bun.sh/) instead of Yarn/NPM to manage JavaScript packages. The switch was quite painless, but our deploy to Heroku failed with the following error:
```
ActionView::Template::Error: Couldn't find the MJML 4. binary.. have you run $ npm install mjml? 

11  # @param input [String] The string to transform in html
12  def initialize(input)
13    raise Mjml.mjml_binary_error_string unless Mjml.valid_mjml_binary
14
15    @input = input
```

After some digging, I realized that we [specifically check for MJML in each given package manager](https://github.com/sighmon/mjml-rails/blob/master/lib/mjml.rb#L49-L54):

```rb
  def self.valid_mjml_binary
    self.valid_mjml_binary = @@valid_mjml_binary ||
                             check_for_custom_mjml_binary ||
                             check_for_yarn_mjml_binary ||
                             check_for_npm_mjml_binary ||
                             check_for_global_mjml_binary ||
                             check_for_mrml_binary

    return @@valid_mjml_binary if @@valid_mjml_binary

    puts Mjml.mjml_binary_error_string
  end
``` 

This PR adds a method to check for the Bun MJML binary.