### PR TITLE
Fix stray stderr output on machines with GNU which

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -74,8 +74,9 @@ module Mjml
   end
 
   def self.check_for_mjml_package(package_manager, bin_command, binary_path)
-    pm_bin = `which #{package_manager}`.chomp
-    return if pm_bin.blank?
+    stdout, _, status = Open3.capture3("which #{package_manager}")
+    return unless status.success?
+    pm_bin = stdout.chomp
 
     stdout, _, status = Open3.capture3("#{pm_bin} #{bin_command}")
     return unless status.success?
@@ -93,11 +94,14 @@ module Mjml
   end
 
   def self.check_for_global_mjml_binary
-    mjml_bin = `which mjml`.chomp
+    stdout, _, status = Open3.capture3("which mjml")
+    return unless status.success?
+    mjml_bin = stdout.chomp
     return mjml_bin if mjml_bin.present? && check_version(mjml_bin)
   end
 
   def self.check_for_mrml_binary
+    return unless Mjml.use_mrml
     MRML.present?
   rescue NameError
     Mjml.mjml_binary_error_string = 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -76,6 +76,7 @@ module Mjml
   def self.check_for_mjml_package(package_manager, bin_command, binary_path)
     stdout, _, status = Open3.capture3("which #{package_manager}")
     return unless status.success?
+
     pm_bin = stdout.chomp
 
     stdout, _, status = Open3.capture3("#{pm_bin} #{bin_command}")
@@ -94,14 +95,16 @@ module Mjml
   end
 
   def self.check_for_global_mjml_binary
-    stdout, _, status = Open3.capture3("which mjml")
+    stdout, _, status = Open3.capture3('which mjml')
     return unless status.success?
+
     mjml_bin = stdout.chomp
     return mjml_bin if mjml_bin.present? && check_version(mjml_bin)
   end
 
   def self.check_for_mrml_binary
     return unless Mjml.use_mrml
+
     MRML.present?
   rescue NameError
     Mjml.mjml_binary_error_string = 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'

--- a/test/fixtures/valid-mjml-binary/empty-path/which
+++ b/test/fixtures/valid-mjml-binary/empty-path/which
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# simulate GNU which's stderr message when it cannot find something
+>&2 echo "I should not show up in test output"
+
+# simulate an empty path by always returning nonzero
+exit 1

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -173,14 +173,14 @@ describe Mjml do
       expect(Mjml.mjml_binary_error_string).must_equal 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'
     end
 
-    it "with nothing on the path, sets valid_mjml_binary to nil" do
-      old_path = ENV["PATH"]
-      ENV["PATH"] = "./test/fixtures/valid-mjml-binary/empty-path/"
+    it 'with nothing on the path, sets valid_mjml_binary to nil' do
+      old_path = ENV['PATH']
+      ENV['PATH'] = './test/fixtures/valid-mjml-binary/empty-path/'
 
       Mjml.stubs(:puts) # silence printed error message from test output
       assert_nil(Mjml.valid_mjml_binary)
     ensure
-      ENV["PATH"] = old_path
+      ENV['PATH'] = old_path
     end
   end
 end

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -168,8 +168,19 @@ describe Mjml do
 
       Mjml.valid_mjml_binary = nil
       MRML.stubs(:present?).raises(NameError)
+      Mjml.stubs(:puts) # silence printed error message from test output
       assert_nil(Mjml.valid_mjml_binary)
       expect(Mjml.mjml_binary_error_string).must_equal 'Couldn\'t find MRML - did you add \'mrml\' to your Gemfile?'
+    end
+
+    it "with nothing on the path, sets valid_mjml_binary to nil" do
+      old_path = ENV["PATH"]
+      ENV["PATH"] = "./test/fixtures/valid-mjml-binary/empty-path/"
+
+      Mjml.stubs(:puts) # silence printed error message from test output
+      assert_nil(Mjml.valid_mjml_binary)
+    ensure
+      ENV["PATH"] = old_path
     end
   end
 end


### PR DESCRIPTION
On a NixOS machine I was getting a message like the following on every Rails boot:

> which: no bun in (... [my path] ...)

I chased it down to this library's usage of `which` to find the mjml binary. Using backticks to call it meant stderr was passing through to the terminal.

Ubuntu and MacOS use different versions of `which` that do not print to stderr, so it's likely not many people have run into this issue.
