### PR TITLE
Improve MJML Mailer Performance by Caching Compiled Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Run the following command to install it:
 bundle install
 ```
 
+After installation, you can generate the MJML initializer file:
+
+```console
+rails generate mjml:install
+```
+
+This will create `config/initializers/mjml.rb` with default configuration options.
+
 Add the MJML parser to your project with your favourite package manager:
 
 ```console
@@ -124,7 +132,7 @@ MJML-Rails has the following settings with defaults:
 
    ERB can be used inside MJML templates by default. Possible values are all template languages that you have installed, e.g. `:haml` or `:slim`.
 
-   **Note:** If you’re using Haml/Slim layouts, please don’t put `<mjml>` in comments in your partial. Read more at [#34](https://github.com/sighmon/mjml-rails/issues/34).
+   **Note:** If you're using Haml/Slim layouts, please don't put `<mjml>` in comments in your partial. Read more at [#34](https://github.com/sighmon/mjml-rails/issues/34).
 
 - `raise_render_exception: true`
 
@@ -154,6 +162,9 @@ MJML-Rails has the following settings with defaults:
 
 - `use_mrml: false`
   Enabling this will allow you to use Rust implementation of MJML via the `mrml` gem. It comes with prebuilt binaries instead of having to install MJML along with Node. When enabled the options `mjml_binary_version_supported`, `mjml_binary`, `minify`, `beautify` and `validation_level` are ignored.
+
+- `cache_mjml: false`
+  By default, MJML-Rails does not cache compiled templates. Setting this to `true` will cache compiled templates in `tmp/mjml_cache` to improve performance for frequently used templates.
 
 - `fonts`
   By default, MJML-Rails uses MJML default fonts, but enables you to override it.
@@ -185,6 +196,9 @@ Mjml.setup do |config|
 
   # Use default system fonts instead of google fonts
   config.fonts = {}
+
+  # Uncomment this to enable template caching
+  # config.cache_mjml = true
 end
 ```
 

--- a/lib/generators/mjml/install/install_generator.rb
+++ b/lib/generators/mjml/install/install_generator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails/generators'
+
+module Mjml
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+      desc 'Creates MJML initializer for your application'
+
+      def copy_initializer
+        template 'mjml.rb', 'config/initializers/mjml.rb'
+      end
+    end
+  end
+end

--- a/lib/generators/mjml/install/templates/mjml.rb
+++ b/lib/generators/mjml/install/templates/mjml.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# MJML configuration
+Mjml.setup do |config|
+  # Use :erb as a template language
+  config.template_language = :erb
+
+  # Raise exceptions for template errors
+  config.raise_render_exception = true
+
+  # Beautify the output HTML
+  config.beautify = true
+
+  # Minify the output HTML
+  config.minify = false
+
+  # Validation level for MJML templates
+  # Possible values: 'strict', 'soft'
+  config.validation_level = 'strict'
+
+  # Use MRML instead of MJML (requires mrml gem)
+  config.use_mrml = false
+
+  # Cache compiled templates for better performance
+  config.cache_mjml = false
+
+  # Custom fonts configuration
+  # Example: config.fonts = { Raleway: 'https://fonts.googleapis.com/css?family=Raleway' }
+  config.fonts = nil
+
+  # Uncomment this to enable template caching
+  # config.cache_mjml = true
+end

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -19,7 +19,8 @@ module Mjml
     :raise_render_exception,
     :template_language,
     :validation_level,
-    :use_mrml
+    :use_mrml,
+    :cache_mjml
 
   mattr_writer :valid_mjml_binary
 

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -34,6 +34,7 @@ module Mjml
   self.validation_level = 'strict'
   self.use_mrml = false
   self.fonts = nil
+  self.cache_mjml = false
 
   def self.check_version(bin)
     stdout, _, status = run_mjml('--version', mjml_bin: bin)

--- a/lib/mjml/cache.rb
+++ b/lib/mjml/cache.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Mjml
+  class Cache
+    attr_reader :template_path
+
+    def initialize(template_path)
+      @template_path = template_path
+    end
+
+    # @yield [] -> String
+    # @return [String]
+    def cache(&block)
+      return yield if !Mjml.cache_mjml && block
+
+      cached_path = cached_file_path
+      if File.exist?(cached_path)
+        File.read(cached_path)
+      else
+        html_content = yield if block
+        File.write(cached_path, html_content)
+        html_content
+      end
+    end
+
+    private
+
+    def cached_file_path
+      File.join(cache_directory, "#{fingerprint}.html")
+    end
+
+    def fingerprint
+      full_path = File.join(Dir.pwd, 'app', 'views', "#{template_path}.mjml")
+      raise "Template file not found: #{full_path}" unless File.exist?(full_path)
+
+      Digest::SHA256.hexdigest(File.read(full_path))
+    end
+
+    def cache_directory
+      dir = File.join(Dir.pwd, 'tmp', 'mjml_cache')
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+      dir
+    end
+  end
+end

--- a/lib/mjml/handler.rb
+++ b/lib/mjml/handler.rb
@@ -17,6 +17,7 @@ module Mjml
       compiled_source = compile_source(source, template)
 
       parser_class = Mjml.use_mrml ? 'MrmlParser' : 'Parser'
+      template_path = template.virtual_path
       # Per MJML v4 syntax documentation[0] valid/render'able document MUST start with <mjml> root tag
       # If we get here and template source doesn't start with one it means
       # that we are rendering partial named according to legacy naming convention (partials ending with '.mjml')
@@ -25,7 +26,7 @@ module Mjml
       #
       # [0] - https://github.com/mjmlio/mjml/blob/master/doc/components_1.md#mjml
       if /<mjml.*?>/i.match?(compiled_source)
-        "Mjml::#{parser_class}.new(begin;#{compiled_source};end).render.html_safe"
+        "Mjml::#{parser_class}.new('#{template_path}', begin;#{compiled_source};end).render.html_safe"
       else
         compiled_source
       end

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -21,6 +21,7 @@ module Mjml
       @with_cache    = Cache.new(template_path)
     end
 
+    # rubocop:disable Metrics/MethodLength
     # Render MJML template
     #
     # @return [String]
@@ -39,6 +40,7 @@ module Mjml
         in_tmp_file&.unlink
       end
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Exec mjml command
     #

--- a/lib/mjml/parser.rb
+++ b/lib/mjml/parser.rb
@@ -1,35 +1,43 @@
 # frozen_string_literal: true
 
+require 'digest'
+require_relative 'cache'
+
 module Mjml
   class Parser
     class ParseError < StandardError; end
 
-    attr_reader :input
+    attr_reader :template_path, :input
 
     # Create new parser
     #
-    # @param input [String] The string to transform in html
-    def initialize(input)
+    # @param template_path [String] The path to the .mjml file
+    # @param input [String] The content of the .mjml file
+    def initialize(template_path, input)
       raise Mjml.mjml_binary_error_string unless Mjml.valid_mjml_binary
 
-      @input = input
+      @template_path = template_path
+      @input         = input
+      @with_cache    = Cache.new(template_path)
     end
 
-    # Render mjml template
+    # Render MJML template
     #
     # @return [String]
     def render
-      in_tmp_file = Tempfile.open(['in', '.mjml']) do |file|
-        file.write(input)
-        file # return tempfile from block so #unlink works later
-      end
-      run(in_tmp_file.path)
-    rescue StandardError
-      raise if Mjml.raise_render_exception
+      @with_cache.cache do
+        in_tmp_file = Tempfile.open(['in', '.mjml']) do |file|
+          file.write(input)
+          file # return tempfile from block so #unlink works later
+        end
+        run(in_tmp_file.path)
+      rescue StandardError
+        raise if Mjml.raise_render_exception
 
-      ''
-    ensure
-      in_tmp_file&.unlink
+        ''
+      ensure
+        in_tmp_file&.unlink
+      end
     end
 
     # Exec mjml command

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 describe Mjml::Parser do
   let(:input) { mock('input') }
-  let(:parser) { Mjml::Parser.new(input) }
+  let(:parser) { Mjml::Parser.new('test_template', input) }
 
   describe '#render' do
     describe 'when exception is raised' do
@@ -42,7 +42,7 @@ describe Mjml::Parser do
         expect(Mjml.beautify).must_equal(true)
         expect(Mjml.minify).must_equal(false)
         expect(Mjml.validation_level).must_equal('strict')
-        expect(Mjml.fonts).must_equal(nil)
+        assert_nil(Mjml.fonts)
       end
 
       it 'uses setup config' do

--- a/test/views/test_template.mjml
+++ b/test/views/test_template.mjml
@@ -1,0 +1,18 @@
+<mjml owa="desktop">
+  <mj-body>
+    <mj-section>
+      <%= render partial: "user_header", formats: [:html] %>
+    </mj-section>
+
+    <mj-section>
+      <mj-column>
+        <mj-text>
+          <h2>We inform you about something</h2>
+          <p>
+            Please visit <a href="https://www.example.com">this link</a>
+          </p>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>


### PR DESCRIPTION
**Problem**
Currently, MJML templates are compiled every time a mailer is called, which significantly slows down test execution. This can impact overall performance, especially in test suites with frequent mailer calls.

**Proposed Solution**
This PR introduces caching for compiled MJML templates, leveraging the fact that mailer templates typically do not change frequently. Compiled templates are now cached in `tmp/mjml_cache`, and if a template is modified, it automatically detects the change, recompiles the template, and updates the cache.

**How it Works:**
1. When a mailer is called, if a cache does not exist, the system calculates a unique fingerprint (using SHA256) based on the content of the template file.
2. The next time the mailer is called with the same template, it retrieves the cached version, resulting in a significant performance boost.

**Caveats:**

**Dynamic data/local variables:** The dynamic data passed from your tests will not be reflected in the cached templates. To avoid this, consider:

1. Using static data in your tests instead of tools like Faker.
2. Writing smarter specs by using regex patterns to check for the presence of values rather than validating exact matches.

If you have suggestions for improving these caveats or avoiding them entirely, I'd love to hear your feedback!