### PR TITLE
Add faster alternative for checking mjml version

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -48,6 +48,7 @@ module Mjml
   def self.valid_mjml_binary
     self.valid_mjml_binary = @@valid_mjml_binary ||
                              check_for_custom_mjml_binary ||
+                             check_for_node_modules_mjml_binary ||
                              check_for_package_mjml_binary ||
                              check_for_global_mjml_binary ||
                              check_for_mrml_binary
@@ -71,6 +72,15 @@ module Mjml
 
     raise "MJML.mjml_binary is set to '#{mjml_binary}' but MJML-Rails could not validate that " \
           'it is a valid MJML binary. Please check your configuration.'
+  end
+
+  def self.check_for_node_modules_mjml_binary
+    package_json = JSON.parse(Rails.root.join('node_modules/mjml/package.json').read)
+    if package_json['version'].start_with?(Mjml.mjml_binary_version_supported)
+      Rails.root.join('node_modules/.bin/mjml').to_s
+    end
+  rescue StandardError
+    false
   end
 
   def self.check_for_mjml_package(package_manager, bin_command, binary_path)

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -159,6 +159,15 @@ describe Mjml do
                                      'but MJML-Rails could not validate that it is a valid MJML binary'))
     end
 
+    it 'checks for node_modules first to avoid running the binary' do
+      Rails.stubs(:root).returns(Pathname.new('.'))
+      Mjml.stubs(:check_for_package_mjml_binary).never
+      Mjml.stubs(:check_for_global_mjml_binary).never
+      Mjml.stubs(:check_for_mrml_binary).never
+
+      expect(Mjml.valid_mjml_binary.to_s).must_match(%r{node_modules/.bin/mjml})
+    end
+
     it 'can use MRML and check for a valid binary' do
       Mjml.use_mrml = true
       Mjml.stubs(:check_for_custom_mjml_binary).returns(false)


### PR DESCRIPTION
Fixes #125.

As I suggested in #125, I assume most people that use Rails and Mjml together _probably_ install Mjml via yarn, and the binary is _probably_ in the `node_modules` folder. If it's in there, we can look for the version number directly in the package's `package.json`, and don't have to actually run it.

The benefit is that this way of checking the version is much, much faster.

If this "happy path" check is unsuccessful, it will fall back to the "classic" version.