### PR TITLE
Allow bun to run without Node.js (standalone)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         package_manager:
           - npm
           - yarn
+          - bun
         rails_version:
           - "~> 8.0"
           - "~> 7.2"
@@ -38,8 +39,14 @@ jobs:
         run: gem install bundler -v 2.4
       - name: Set up Node
         uses: actions/setup-node@v3
+        if: ${{ contains(fromJSON('["npm", "yarn"]'), matrix.package_manager) }}
         with:
           node-version: "22"
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        if: ${{ matrix.package_manager == 'bun' }}
+        with:
+          bun-version: 1.1.42
       - name: Install rails dependencies
         env:
           RAILS_VERSION: ${{ matrix.rails_version }}
@@ -55,6 +62,9 @@ jobs:
       - name: Install mjml with yarn
         if: ${{ matrix.package_manager == 'yarn' }}
         run: yarn add mjml
+      - name: Install mjml with bun
+        if: ${{ matrix.package_manager == 'bun' }}
+        run: bun add mjml
       - name: Run tests
         env:
           RAILS_VERSION: ${{ matrix.rails_version }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,8 @@ AllCops:
   DisplayCopNames: true
   NewCops: enable
 
-
+Metrics/ModuleLength:
+  Max: 120
 Metrics/BlockLength:
   IgnoredMethods:
     - describe

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -48,6 +48,7 @@ module Mjml
   def self.valid_mjml_binary
     self.valid_mjml_binary = @@valid_mjml_binary ||
                              check_for_custom_mjml_binary ||
+                             check_for_bun_mjml_binary ||
                              check_for_package_mjml_binary ||
                              check_for_global_mjml_binary ||
                              check_for_mrml_binary
@@ -88,9 +89,18 @@ module Mjml
     nil
   end
 
+  def self.check_for_bun_mjml_binary
+    _, _, status = Open3.capture3('which bun')
+    return unless status.success?
+
+    # HINT: Bun always prioritizes local bins first and falls back to global installations
+    mjml_bin = 'bun run mjml'
+
+    return mjml_bin if check_version(mjml_bin)
+  end
+
   def self.check_for_package_mjml_binary
-    check_for_mjml_package('bun', 'pm bin', ['mjml']) ||
-      check_for_mjml_package('npm', 'root', ['.bin', 'mjml']) ||
+    check_for_mjml_package('npm', 'root', ['.bin', 'mjml']) ||
       check_for_mjml_package('yarn', 'bin mjml', [])
   end
 

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -162,6 +162,7 @@ describe Mjml do
     it 'can use MRML and check for a valid binary' do
       Mjml.use_mrml = true
       Mjml.stubs(:check_for_custom_mjml_binary).returns(false)
+      Mjml.stubs(:check_for_bun_mjml_binary).returns(false)
       Mjml.stubs(:check_for_package_mjml_binary).returns(false)
       Mjml.stubs(:check_for_global_mjml_binary).returns(false)
       expect(Mjml.valid_mjml_binary).must_equal(true)


### PR DESCRIPTION
Why:
Bun is a drop-in replacement for Node.js and does not rely on Node.js. In other words: You should be able use bun without any node installation in your system.

MJML js bin file has a shebang comment to rely on node. If bun encounters a shebang comment like this is it will either spawn a node process (https://bun.sh/docs/cli/run#bun) or it has fallback to a node cli wrapper script (AFAIK).

The current mjml-rails implementation does not rely on the bun cli command, instead it just searches the bun installed bin and runs it. This will fail if node is not installed on the system.

e.g.:
```
$ bun add mjml@^4.15.3 # installed mjml@4.15.3 with binaries: - mjml
$ bun pm bin #/Users/mjml-fan/mjml-rails/node_modules/.bin
$ /Users/mjml-fan/mjml-rails/node_modules/.bin/mjml --version #env: node: No such file or directory
```

Using bun will resolve the issue:
```
$ bun run mjml --version # mjml-core: 4.15.3...
```

The implementation will resolve bun's locally installed bin first and falls back to bun's globally installed bin. If this fails it will continue with other installations.