### PR TITLE
Prioritize mrml binary

### DIFF
--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -59,10 +59,10 @@ module Mjml
   def self.valid_mjml_binary
     self.valid_mjml_binary = @@valid_mjml_binary ||
                              check_for_custom_mjml_binary ||
+                             check_for_mrml_binary ||
                              check_for_bun_mjml_binary ||
                              check_for_package_mjml_binary ||
-                             check_for_global_mjml_binary ||
-                             check_for_mrml_binary
+                             check_for_global_mjml_binary
 
     return @@valid_mjml_binary if @@valid_mjml_binary
 


### PR DESCRIPTION
Resolves: https://github.com/sighmon/mjml-rails/issues/134

This MR prioritizes the `mrml` binary when finding a valid mjml/mrml binary.

At startup, the library searches for all kinds of binaries to find a valid mjml/mrml binary. When use_mrml is set to true, that search is not necessary, and can even be wrong when another dependency introduces mjml somewhere in the path.

In our specific case, we have monitors whenever a process attempts to execute a command as root, which happens here: https://github.com/sighmon/mjml-rails/blob/master/lib/mjml.rb#L111

All of the above could be avoided if the check_for_mrml_binary happens at the top of the chain. It's pretty clear that whenever use_mrml is true, and when check_for_mrml_binary succeeds, we've found a valid MJML/MRML binary.

