### PR TITLE
MRML caching

### DIFF
--- a/lib/mjml/mrml_parser.rb
+++ b/lib/mjml/mrml_parser.rb
@@ -2,27 +2,32 @@
 
 module Mjml
   class MrmlParser
-    attr_reader :input
+    attr_reader :template_path, :input
 
     # Create new parser
     #
+    # @param template_path [String] The path to the .mjml file
     # @param input [String] The string to transform in html
-    def initialize(input)
-      @input = input
+    def initialize(template_path, input)
+      @template_path = template_path
+      @input         = input
+      @with_cache    = Cache.new(template_path)
     end
 
     # Render mjml template
     #
     # @return [String]
     def render
-      MRML.to_html(input)
-    rescue NameError
-      Mjml.logger.fatal('MRML is not installed. Please add `gem "mrml"` to your Gemfile.')
-      raise
-    rescue StandardError
-      raise if Mjml.raise_render_exception
+      @with_cache.cache do
+        MRML.to_html(input)
+      rescue NameError
+        Mjml.logger.fatal('MRML is not installed. Please add `gem "mrml"` to your Gemfile.')
+        raise
+      rescue StandardError
+        raise if Mjml.raise_render_exception
 
-      ''
+        ''
+      end
     end
   end
 end

--- a/test/mrml_parser_test.rb
+++ b/test/mrml_parser_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 describe Mjml::MrmlParser do
-  let(:parser) { Mjml::MrmlParser.new(input) }
+  let(:parser) { Mjml::MrmlParser.new('test_template', input) }
 
   describe '#render' do
     describe 'when input is valid' do


### PR DESCRIPTION
Currently, MRML can't be used in 4.15.0 because the MrmlParser constructor wasn't updated when caching was added.