### PR TITLE
  Fix NoMethodError for ViewComponent templates (#138)

### DIFF
--- a/lib/mjml/handler.rb
+++ b/lib/mjml/handler.rb
@@ -17,7 +17,7 @@ module Mjml
       compiled_source = compile_source(source, template)
 
       parser_class = Mjml.use_mrml ? 'MrmlParser' : 'Parser'
-      template_path = template.virtual_path
+      template_path = template.respond_to?(:virtual_path) ? template.virtual_path : template.identifier
       # Per MJML v4 syntax documentation[0] valid/render'able document MUST start with <mjml> root tag
       # If we get here and template source doesn't start with one it means
       # that we are rendering partial named according to legacy naming convention (partials ending with '.mjml')

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HandlerTest < ActiveSupport::TestCase
+  def setup
+    @handler = Mjml::Handler.new
+  end
+
+  test 'uses virtual_path when available' do
+    template = mock
+    template.stubs(:virtual_path).returns('/path/to/template')
+    template.stubs(:respond_to?).with(:virtual_path).returns(true)
+
+    compiled_source = '<mjml><mj-body><mj-text>Hello</mj-text></mj-body></mjml>'
+    @handler.stubs(:compile_source).returns(compiled_source)
+
+    result = @handler.call(template)
+
+    assert_includes result, '/path/to/template'
+  end
+
+  test 'falls back to identifier when virtual_path is not available' do
+    # Simulate ViewComponent::Template::DataWithSource behavior
+    template = mock
+    template.stubs(:identifier).returns('/path/to/component/template')
+    template.stubs(:respond_to?).with(:virtual_path).returns(false)
+
+    compiled_source = '<mjml><mj-body><mj-text>Hello</mj-text></mj-body></mjml>'
+    @handler.stubs(:compile_source).returns(compiled_source)
+
+    result = @handler.call(template)
+
+    assert_includes result, '/path/to/component/template'
+  end
+
+  test 'handles partials without mjml root tag' do
+    template = mock
+    template.stubs(:virtual_path).returns('/path/to/partial')
+    template.stubs(:respond_to?).with(:virtual_path).returns(true)
+
+    # Partial without <mjml> root tag
+    compiled_source = '<mj-text>This is a partial</mj-text>'
+    @handler.stubs(:compile_source).returns(compiled_source)
+
+    result = @handler.call(template)
+
+    # Should return the compiled source as-is for partials
+    assert_equal compiled_source, result
+  end
+
+  test 'processes full MJML documents' do
+    template = mock
+    template.stubs(:virtual_path).returns('/path/to/template')
+    template.stubs(:respond_to?).with(:virtual_path).returns(true)
+
+    compiled_source = '<mjml><mj-body><mj-text>Full document</mj-text></mj-body></mjml>'
+    @handler.stubs(:compile_source).returns(compiled_source)
+
+    result = @handler.call(template)
+
+    # Should return parser invocation for full MJML documents
+    assert_includes result, "Mjml::Parser.new('/path/to/template'"
+    assert_includes result, '.render.html_safe'
+  end
+
+  test 'uses MrmlParser when use_mrml is true' do
+    Mjml.stubs(:use_mrml).returns(true)
+
+    template = mock
+    template.stubs(:virtual_path).returns('/path/to/template')
+    template.stubs(:respond_to?).with(:virtual_path).returns(true)
+
+    compiled_source = '<mjml><mj-body><mj-text>Full document</mj-text></mj-body></mjml>'
+    @handler.stubs(:compile_source).returns(compiled_source)
+
+    result = @handler.call(template)
+
+    assert_includes result, "Mjml::MrmlParser.new('/path/to/template'"
+  ensure
+    Mjml.unstub(:use_mrml)
+  end
+end


### PR DESCRIPTION
## Summary

  This PR fixes the `NoMethodError: undefined method 'virtual_path'` error that occurs when using
  mjml-rails with ViewComponent templates after upgrading to version 4.15.0.

  ## Problem

  ViewComponent's `Template::DataWithSource` struct doesn't have a `virtual_path` method, causing the
  handler to fail when processing ViewComponent templates. The error was introduced in the recent
  template caching implementation.

  ## Solution

  Modified the handler to check if `virtual_path` exists before calling it, falling back to
  `identifier` if it doesn't:

  ```ruby
  template_path = template.respond_to?(:virtual_path) ? template.virtual_path : template.identifier

  This maintains compatibility with both ActionView templates (which have virtual_path) and
  ViewComponent templates (which have identifier).