### PR TITLE
Remove duplicated setting in generated template

### DIFF
--- a/lib/generators/mjml/install/templates/mjml.rb
+++ b/lib/generators/mjml/install/templates/mjml.rb
@@ -27,7 +27,4 @@ Mjml.setup do |config|
   # Custom fonts configuration
   # Example: config.fonts = { Raleway: 'https://fonts.googleapis.com/css?family=Raleway' }
   config.fonts = nil
-
-  # Uncomment this to enable template caching
-  # config.cache_mjml = true
 end


### PR DESCRIPTION
The `onfig.cache_mjml` setting is duplicated in a generated initializer file. I think L30-32 can be simply removed since that's already declared at L25.