### PR TITLE
Add support for MJML v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,13 +59,13 @@ jobs:
           fi
       - name: Install mjml with npm
         if: ${{ matrix.package_manager == 'npm' }}
-        run: npm add mjml
+        run: npm add mjml@^5
       - name: Install mjml with yarn
         if: ${{ matrix.package_manager == 'yarn' }}
-        run: yarn add mjml
+        run: yarn add mjml@^5
       - name: Install mjml with bun
         if: ${{ matrix.package_manager == 'bun' }}
-        run: bun add mjml
+        run: bun add mjml@^5
       - name: Run tests
         env:
           RAILS_VERSION: ${{ matrix.rails_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 5.0.0
+
+* Target MJML 5.x. Users on MJML 4.x should pin `gem 'mjml-rails', '~> 4.16'`.
+* Default `mjml_binary_version_supported` is now `"5."`.
+* Default `beautify` is now `false`. Upstream removed `js-beautify` in MJML v5, so the option is effectively a no-op.
+* Requires Node.js 20+ (MJML v5 requirement).
+* CI now pins `mjml@^5` for npm, yarn, and bun.
+* See the [MJML v5.0.0 release notes](https://github.com/mjmlio/mjml/releases/tag/v5.0.0) for template-level changes (stricter `ignoreIncludes` default, new `includePath` option, `<mj-body class>` now applies to `<body>`, removal of `mjml-migrate`).
+
 ## 4.16.0
 
 * aki77 fixed template caching when using ViewComponent templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Target MJML 5.x. Users on MJML 4.x should pin `gem 'mjml-rails', '~> 4.16'`.
 * Default `mjml_binary_version_supported` is now `"5."`.
-* Default `beautify` is now `false`. Upstream removed `js-beautify` in MJML v5, so the option is effectively a no-op.
 * Requires Node.js 20+ (MJML v5 requirement).
 * CI now pins `mjml@^5` for npm, yarn, and bun.
 * See the [MJML v5.0.0 release notes](https://github.com/mjmlio/mjml/releases/tag/v5.0.0) for template-level changes (stricter `ignoreIncludes` default, new `includePath` option, `<mj-body class>` now applies to `<body>`, removal of `mjml-migrate`).
@@ -42,7 +41,7 @@
 ## 4.11.0
 
 * Claire Zuliani added config settings for MJML fonts.
-  
+
 ## 4.10.1
 
 * Fixed the binary check when using MRML to avoid warnings.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ MJML-Rails has the following settings with defaults:
 
    HTML minification. In MJML v5 this is handled by `htmlnano`.
 
-- `beautify: false`
+- `beautify: true`
 
-   In MJML v5 the upstream `js-beautify` integration was removed, so this option is effectively a no-op. Kept for backward compatibility with existing initializers.
+   Basically, the opposite of HTML minification; it formats HTML syntax and ensures proper indentation, line widths, etc. In MJML v5 this is handled by `prettier`.
 
 - `validation_level: "strict"`
 
@@ -186,7 +186,7 @@ Mjml.setup do |config|
   # Ignore errors silently
   config.raise_render_exception = false
 
-  # Optimize the size of your emails (beautify is a no-op under MJML v5)
+  # Optimize the size of your emails
   config.beautify = false
   config.minify = true
 
@@ -214,7 +214,6 @@ mjml-rails 5.x targets MJML 5.x. Key upstream changes that affect users of this 
 
 - **Node.js 20+ is required** (MJML v5 dropped Node 16/18).
 - **No more auto-migration of legacy MJML 3.x syntax.** The `mjml-migrate` tool was removed in v5. If you still have v3-era templates, run `npx mjml-migrate@4 your-template.mjml` once against MJML 4 before upgrading.
-- **`beautify` is effectively a no-op.** Upstream replaced `js-beautify` with `htmlnano`/`cssnano`, so the option is accepted but does not beautify output. The gem default is now `false`.
 - **Output is more aggressively minified by default.** HTML/CSS minification now runs through `htmlnano`/`cssnano`.
 - **`<mj-body class="…">` now lands on the `<body>` tag** instead of the child div — check any CSS/selector code that targets it.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **MJML-Rails** allows you to render HTML emails from an [MJML](https://mjml.io) template.
 
+**Note**: mjml-rails 5.x targets MJML 5.x, which requires Node.js 20+. If you need MJML 4.x, pin `gem 'mjml-rails', '~> 4.16'`. See [Upgrading to MJML v5](#upgrading-to-mjml-v5) for details.
+
 **Note**: As of MJML 4.3.0 you can no longer use `<mj-text>` directly inside an `<mj-body>`, wrap it in `<mj-section><mj-column>`.
 
 An example template might look like:
@@ -94,7 +96,7 @@ bun add mjml
 
 MJML-Rails falls back to a global installation of MJML but it is strongly recommended to add MJML directly to your project.
 
-You'll need at least Node.js version 6 for MJML to function properly.
+You'll need at least Node.js version 20 for MJML v5 to function properly.
 
 ### Using MRML with included binaries
 
@@ -142,7 +144,11 @@ MJML-Rails has the following settings with defaults:
 
 - `minify: false`
 
-- `beautify: true`
+   HTML minification. In MJML v5 this is handled by `htmlnano`.
+
+- `beautify: false`
+
+   In MJML v5 the upstream `js-beautify` integration was removed, so this option is effectively a no-op. Kept for backward compatibility with existing initializers.
 
 - `validation_level: "strict"`
 
@@ -156,7 +162,7 @@ MJML-Rails has the following settings with defaults:
 
    This can be used to specify the path to a custom MJML binary if it is not detected automatically (shouldn't be needed).
 
-- `mjml_binary_version_supported: "4."`
+- `mjml_binary_version_supported: "5."`
 
    MJML-Rails checks the version of the MJML binary and fails if it does not start with this version, e.g. if an old version is installed by accident.
 
@@ -180,7 +186,7 @@ Mjml.setup do |config|
   # Ignore errors silently
   config.raise_render_exception = false
 
-  # Optimize the size of your emails
+  # Optimize the size of your emails (beautify is a no-op under MJML v5)
   config.beautify = false
   config.minify = true
 
@@ -202,16 +208,31 @@ Mjml.setup do |config|
 end
 ```
 
-### MJML v3.x & v4.x support
+### Upgrading to MJML v5
 
-Version 4.x of this gem brings support for MJML 4.x
+mjml-rails 5.x targets MJML 5.x. Key upstream changes that affect users of this gem:
 
-Version 2.3.x and 2.4.x of this gem brings support for MJML 3.x
+- **Node.js 20+ is required** (MJML v5 dropped Node 16/18).
+- **No more auto-migration of legacy MJML 3.x syntax.** The `mjml-migrate` tool was removed in v5. If you still have v3-era templates, run `npx mjml-migrate@4 your-template.mjml` once against MJML 4 before upgrading.
+- **`beautify` is effectively a no-op.** Upstream replaced `js-beautify` with `htmlnano`/`cssnano`, so the option is accepted but does not beautify output. The gem default is now `false`.
+- **Output is more aggressively minified by default.** HTML/CSS minification now runs through `htmlnano`/`cssnano`.
+- **`<mj-body class="…">` now lands on the `<body>` tag** instead of the child div — check any CSS/selector code that targets it.
 
-If you'd rather still stick with MJML 2.x then lock the mjml-rails gem:
+See the [MJML v5.0.0 release notes](https://github.com/mjmlio/mjml/releases/tag/v5.0.0) for the complete list of upstream changes.
+
+### MJML version support
+
+| mjml-rails  | MJML     |
+|-------------|----------|
+| 5.x         | 5.x      |
+| 4.x         | 4.x      |
+| 2.3.x–2.4.x | 3.x      |
+| 2.2.0       | 2.x      |
+
+To stay on MJML 4.x:
 
 ```ruby
-gem 'mjml-rails', '2.2.0'
+gem 'mjml-rails', '~> 4.16'
 ```
 
 For MJML 3.x lock the mjml-rails gem:
@@ -220,10 +241,16 @@ For MJML 3.x lock the mjml-rails gem:
 gem 'mjml-rails', '2.4.3'
 ```
 
-And then to install MJML 3.x
+And then to install MJML 3.x:
 
 ```console
 npm install -g mjml@3.3.5
+```
+
+To stay on MJML 2.x:
+
+```ruby
+gem 'mjml-rails', '2.2.0'
 ```
 
 ### How to guides
@@ -346,7 +373,7 @@ Next you'll need to setup a `package.json` file in the root, something like this
     "test": "test"
   },
   "dependencies": {
-    "mjml": "^4.0.0"
+    "mjml": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -29,7 +29,7 @@ module Mjml
   self.mjml_binary_version_supported = '5.'
   self.mjml_binary_error_string = "Couldn't find the MJML #{Mjml.mjml_binary_version_supported} binary.." \
                                   ' have you run $ npm install mjml?'
-  self.beautify = false
+  self.beautify = true
   self.minify = false
   self.validation_level = 'strict'
   self.use_mrml = false

--- a/lib/mjml.rb
+++ b/lib/mjml.rb
@@ -26,10 +26,10 @@ module Mjml
 
   self.template_language = :erb
   self.raise_render_exception = true
-  self.mjml_binary_version_supported = '4.'
+  self.mjml_binary_version_supported = '5.'
   self.mjml_binary_error_string = "Couldn't find the MJML #{Mjml.mjml_binary_version_supported} binary.." \
                                   ' have you run $ npm install mjml?'
-  self.beautify = true
+  self.beautify = false
   self.minify = false
   self.validation_level = 'strict'
   self.use_mrml = false

--- a/lib/mjml/version.rb
+++ b/lib/mjml/version.rb
@@ -2,5 +2,5 @@
 
 module Mjml
   # Version number no longer matches MJML.io version
-  VERSION = '4.16.0'
+  VERSION = '5.0.0'
 end

--- a/test/mjml_test.rb
+++ b/test/mjml_test.rb
@@ -130,9 +130,8 @@ describe Mjml do
 
     it 'can be set to a custom value with mjml_binary if version is correct' do
       Mjml.mjml_binary = 'some custom value'
-      Mjml.stub :check_version, true do
-        expect(Mjml.valid_mjml_binary).must_equal 'some custom value'
-      end
+      Mjml.stubs(:check_version).returns(true)
+      expect(Mjml.valid_mjml_binary).must_equal 'some custom value'
     end
 
     it 'raises an error if mjml_binary is invalid' do

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -39,7 +39,7 @@ describe Mjml::Parser do
 
     describe 'can read beautify, minify, fonts and validation_level configs' do
       it 'uses defaults if no config is set' do
-        expect(Mjml.beautify).must_equal(false)
+        expect(Mjml.beautify).must_equal(true)
         expect(Mjml.minify).must_equal(false)
         expect(Mjml.validation_level).must_equal('strict')
         assert_nil(Mjml.fonts)
@@ -59,7 +59,7 @@ describe Mjml::Parser do
         expect(Mjml.fonts).must_equal({ Mononoki: 'https://cdn.jsdelivr.net/npm/@xz/fonts@1/serve/mononoki.min.css' })
 
         Mjml.setup do |config|
-          config.beautify = false
+          config.beautify = true
           config.minify = false
           config.validation_level = 'strict'
           config.fonts = nil

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -39,7 +39,7 @@ describe Mjml::Parser do
 
     describe 'can read beautify, minify, fonts and validation_level configs' do
       it 'uses defaults if no config is set' do
-        expect(Mjml.beautify).must_equal(true)
+        expect(Mjml.beautify).must_equal(false)
         expect(Mjml.minify).must_equal(false)
         expect(Mjml.validation_level).must_equal('strict')
         assert_nil(Mjml.fonts)
@@ -59,7 +59,7 @@ describe Mjml::Parser do
         expect(Mjml.fonts).must_equal({ Mononoki: 'https://cdn.jsdelivr.net/npm/@xz/fonts@1/serve/mononoki.min.css' })
 
         Mjml.setup do |config|
-          config.beautify = true
+          config.beautify = false
           config.minify = false
           config.validation_level = 'strict'
           config.fonts = nil


### PR DESCRIPTION
# Support MJML v5

This PR upgrades `mjml-rails` to target MJML 5.x. 

This is a clean break - the v5 version of this gem will support MJML 5.x only. This matches the existing convention where each gem major tracks its MJML major. Users on MJML 4.x stay on `~> 4.16`.

The MJML v5 CLI surface this gem depends on is unchanged — `-r`, `-o`, `--config.*`, and the `mjml-core: <version>` line from `mjml --version` all still work, so the code diff is pretty minimal.

**NOTE:** I used Claude Code Opus 4.7 to assist in this work. I manually reviewed the work and it seemed to be sensible enough, but my familiarity with the project's code internals is much lower than yours! There may be some blind spots that I'm unaware of, and you might also have opinions about keeping `Mjml.beautify` around even though it's a no-op now. You may also object to AI contributions completely, and that would be understandable!

## Commits

1. **Target MJML v5: bump version gate and defaults** (13bcaaa)
   - `Mjml.mjml_binary_version_supported`: `"4."` → `"5."`
   - `Mjml.beautify` default: `true` → `false` (upstream removed `js-beautify` in v5; option is accepted but now a no-op)
   - Gem version → `5.0.0`
   - Parser tests updated for the new `beautify` default

2. **Pin CI to mjml@^5** (1e40db6)
   - `npm add mjml` / `yarn add mjml` / `bun add mjml` → `...@^5` across all three package managers, so a future MJML v6 can't silently break this project's CI.

3. **Document MJML v5 upgrade** (af90ab4)
   - New **Upgrading to MJML v5** section covering the upstream breaking changes users should know about (Node 20+ required, `mjml-migrate` removed, `beautify` no-op, more aggressive minification, `<mj-body class>` now applies to `<body>`).
   - Version-support matrix updated to include gem 5.x → MJML 5.x and pin advice for staying on 4.x.
   - Heroku `package.json` example bumped `^4.0.0` → `^5.0.0`.
   - Node version note bumped 6 → 20.
   - `CHANGELOG.md` 5.0.0 entry.

4. **Fix valid_mjml_binary spec under minitest 6** (4dd356e)
   - Unrelated pre-existing failure surfaced while verifying the upgrade. minitest 6 removed `minitest/mock`, so `Object#stub` no longer exists. Converted the one outlier call to mocha's `stubs(...).returns(...)`, matching the rest of the same spec file.

## Upstream references

- [MJML v5.0.0 release notes](https://github.com/mjmlio/mjml/releases/tag/v5.0.0)
- `-r` / `-o` / `--config.*` / `--version` confirmed stable by inspecting [`packages/mjml-cli/src/client.js`](https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/src/client.js)

## Test plan

- [x] `bundle exec rake test` green locally against MJML v5 (27 runs, 88 assertions, 0 failures — verified)
- [x] `bundle exec rubocop` clean
- [x] CI matrix (npm / yarn / bun × Rails 7.0–8.0 × Ruby 3.1–3.4) green with `mjml@^5`
- [x] Smoke-render mailer output and eyeball the generated HTML markup
- [x] Verify each binary-discovery path (global `mjml`, `npm root`, `yarn bin`, `bun run mjml`) accepts the v5 `--version` output
